### PR TITLE
Moving webview convenience method to a better home

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,23 +21,6 @@ enum OnboardingWizardState {
     projectCreated
 }
 
-export function showInstructionWebView(
-    extensionUri: vscode.Uri,
-    tabName: string,
-    htmlPath: string
-) {
-    const provider: InstructionsWebviewProvider =
-        new InstructionsWebviewProvider(extensionUri);
-    provider.showInstructionWebview(tabName, htmlPath, [
-        {
-            buttonId: 'okButton',
-            action: (panel) => {
-                panel.dispose();
-            }
-        }
-    ]);
-}
-
 export function activate(context: vscode.ExtensionContext) {
     // If activation is coming as the result of the project being created and newly
     // loaded into the workspace, pick up with the next step of the wizard.
@@ -56,8 +39,8 @@ export function activate(context: vscode.ExtensionContext) {
                 await OnboardingCommands.setupBriefcase(context.extensionUri);
                 await LandingPageCommand.execute();
 
-                showInstructionWebView(
-                    context.extension.extensionUri,
+                InstructionsWebviewProvider.showDismissableInstructions(
+                    context.extensionUri,
                     messages.getMessage('salesforce_mobile_app_instruction'),
                     'src/instructions/salesforcemobileapp.html'
                 );

--- a/src/onboardingCommands.ts
+++ b/src/onboardingCommands.ts
@@ -8,7 +8,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { CommonUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/CommonUtils';
-import { showInstructionWebView } from './extension';
+import { InstructionsWebviewProvider } from './webviews';
 import { messages } from './messages/messages';
 
 export class OnboardingCommands {
@@ -147,7 +147,7 @@ export class OnboardingCommands {
             }
         );
 
-        showInstructionWebView(
+        InstructionsWebviewProvider.showDismissableInstructions(
             extensionUri,
             messages.getMessage('briefcase_setup_instruction'),
             'src/instructions/briefcase.html'

--- a/src/webviews.ts
+++ b/src/webviews.ts
@@ -57,4 +57,21 @@ export class InstructionsWebviewProvider {
         );
         panel.webview.html = webviewContent;
     }
+
+    public static showDismissableInstructions(
+        extensionUri: vscode.Uri,
+        title: string,
+        contentPath: string
+    ) {
+        const provider: InstructionsWebviewProvider =
+            new InstructionsWebviewProvider(extensionUri);
+        provider.showInstructionWebview(title, contentPath, [
+            {
+                buttonId: 'okButton',
+                action: (panel) => {
+                    panel.dispose();
+                }
+            }
+        ]);
+    }
 }


### PR DESCRIPTION
The convenience method that @sfdctaka created in https://github.com/salesforce/salesforce-offline-vscode/pull/7 is a good one, but it should live under the responsibility of the `InstructionsWebviewProvider` that manages that webview code. Minor PR to move it over.