### PR TITLE
Pruning dev is breaking vsce packaging

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,8 +14,6 @@ The following instructions will create the extension package (`salesforcedx-vsco
 
         npx vsce package
 
-    **NOTE:** The packaging workflow prunes the dev dependencies out of the `node_modules/` tree, so you'll need to re-run `npm install` to reinstall dev dependencies and continue development work.
-
 3.  Install the generated .vsix file and test as you will:
 
         code --install-extension salesforcedx-vscode-mobile-<version>.vsix

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prettier:write": "prettier --write \"src/**/*.{ts, js}\"",
     "prettier:verify": "prettier --list-different \"src/**/*.{ts, js}\"",
     "bundle:extension": "esbuild ./src/extension.ts  --bundle --outdir=out --format=cjs --target=es2020 --platform=node --external:vscode --external:@oclif/core --minify --sourcemap",
-    "vscode:prepublish": "npm run clean && npm run bundle:extension && npm prune --omit=dev"
+    "vscode:prepublish": "npm run clean && npm run bundle:extension"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",


### PR DESCRIPTION
The size of the bundle doesn't change, and doing the dev pruning is otherwise breaking `vsce` when installed as a dev dependency.

Let's save the file culling for when we optimize the package.