### PR TITLE
Install package, to use vsce dependency for publish

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -20,6 +20,9 @@ jobs:
               with:
                   node-version: '16.x'
 
+            - name: Install dependencies
+              run: npm install
+
             - name: Validate tag name
               id: validate_tag_name
               uses: actions/github-script@v6


### PR DESCRIPTION
I noticed in the publish flow that `npx vsce publish` downloaded and installed `vsce` (and complained about not using its full package name), because we weren't installing the package dependencies of the project.