### PR TITLE
Fixing Node engine, Volta versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
+        "node": ">=18",
         "vscode": "^1.77.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "0.2.0",
   "publisher": "salesforce",
   "engines": {
-    "vscode": "^1.77.0"
+    "vscode": "^1.77.0",
+    "node": ">=18"
   },
   "categories": [
     "Other"
@@ -40,7 +41,7 @@
     ]
   },
   "volta": {
-    "node": ">=18"
+    "node": "18.17.1"
   },
   "scripts": {
     "clean": "rimraf out",


### PR DESCRIPTION
Volta does not support version ranges on pinning, so using Volta with the previous `>=18` version was actually breaking for Volta installations.

Moved our Node engine minimum version to the `engines` configuration, and pinned Node 18 for Volta at the latest version.