### PR TITLE
Get correct compact layout for sObject

### DIFF
--- a/src/commands/wizard/lwcGenerationCommand.ts
+++ b/src/commands/wizard/lwcGenerationCommand.ts
@@ -80,9 +80,10 @@ export class LwcGenerationCommand {
                     {
                         type: 'getQuickActionStatus',
                         action: async (_panel, _data, callback) => {
-                            await OrgUtils.getCompactLayoutForSObject(
-                                'Contact'
-                            );
+                            const layoutFields =
+                                await OrgUtils.getCompactLayoutFieldsForSObject(
+                                    'Contact'
+                                );
 
                             // TODO: Hook this up to function that parses landing_page.json.
                             const sobjects = [

--- a/src/commands/wizard/lwcGenerationCommand.ts
+++ b/src/commands/wizard/lwcGenerationCommand.ts
@@ -80,21 +80,17 @@ export class LwcGenerationCommand {
                     {
                         type: 'getQuickActionStatus',
                         action: async (_panel, _data, callback) => {
-                            const layoutFields =
-                                await OrgUtils.getCompactLayoutFieldsForSObject(
-                                    'Contact'
-                                );
-
-                            // TODO: Hook this up to function that parses landing_page.json.
-                            const sobjects = [
-                                'Account',
-                                'Contact',
-                                'Opportunity',
-                                'SomeOther'
-                            ];
                             if (callback) {
                                 const quickActionStatus =
                                     await LwcGenerationCommand.checkForExistingQuickActions();
+
+                                for (const key in quickActionStatus.sobjects) {
+                                    const layoutFields =
+                                        await OrgUtils.getCompactLayoutFieldsForSObject(
+                                            key
+                                        );
+                                }
+
                                 callback(quickActionStatus);
                             }
                         }

--- a/src/commands/wizard/lwcGenerationCommand.ts
+++ b/src/commands/wizard/lwcGenerationCommand.ts
@@ -4,6 +4,7 @@ import { InstructionsWebviewProvider } from '../../webviews/instructions';
 import { UEMParser } from '../../utils/uemParser';
 import { WorkspaceUtils } from '../../utils/workspaceUtils';
 import { CommonUtils } from '@salesforce/lwc-dev-mobile-core';
+import { OrgUtils } from '../../utils/orgUtils';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -79,6 +80,17 @@ export class LwcGenerationCommand {
                     {
                         type: 'getQuickActionStatus',
                         action: async (_panel, _data, callback) => {
+                            await OrgUtils.getCompactLayoutForSObject(
+                                'Contact'
+                            );
+
+                            // TODO: Hook this up to function that parses landing_page.json.
+                            const sobjects = [
+                                'Account',
+                                'Contact',
+                                'Opportunity',
+                                'SomeOther'
+                            ];
                             if (callback) {
                                 const quickActionStatus =
                                     await LwcGenerationCommand.checkForExistingQuickActions();

--- a/src/test/suite/utils/orgUtils.test.ts
+++ b/src/test/suite/utils/orgUtils.test.ts
@@ -185,7 +185,7 @@ suite('Org Utils Test Suite', () => {
         };
 
         sinon
-            .stub(OrgUtils, 'getAllCompactLayoutsForSObject')
+            .stub(OrgUtils, 'getCompactLayoutsForSObject')
             .returns(Promise.resolve(allCompactLayouts));
         sinon
             .stub(OrgUtils, 'getCompactLayoutForSObject')
@@ -253,7 +253,7 @@ suite('Org Utils Test Suite', () => {
         };
 
         sinon
-            .stub(OrgUtils, 'getAllCompactLayoutsForSObject')
+            .stub(OrgUtils, 'getCompactLayoutsForSObject')
             .returns(Promise.resolve(allCompactLayouts));
         sinon
             .stub(OrgUtils, 'getCompactLayoutForSObject')

--- a/src/test/suite/utils/orgUtils.test.ts
+++ b/src/test/suite/utils/orgUtils.test.ts
@@ -140,6 +140,132 @@ suite('Org Utils Test Suite', () => {
         assert.equal(sobject.labelPlural, 'Labels');
     });
 
+    test('Returns SYSTEM compact layout', async () => {
+        // Simplified all compact layout data structure
+        const allCompactLayouts = {
+            defaultCompactLayoutId: null,
+            recordTypeCompactLayoutMappings: [
+                {
+                    available: true,
+                    compactLayoutId: null,
+                    compactLayoutName: 'SYSTEM',
+                    recordTypeId: '012000000000000AAA',
+                    recordTypeName: 'Master',
+                    urls: {
+                        compactLayout:
+                            '/services/data/v59.0/sobjects/Contact/describe/compactLayouts/012000000000000AAA'
+                    }
+                }
+            ]
+        };
+
+        // Simplified compact layout data structure
+        const compactLayout = {
+            fieldItems: [
+                {
+                    editableForNew: true,
+                    editableForUpdate: true,
+                    label: 'Name'
+                },
+                {
+                    editableForNew: true,
+                    editableForUpdate: true,
+                    label: 'Title'
+                },
+                {
+                    editableForNew: false,
+                    editableForUpdate: false,
+                    label: 'Contact Owner'
+                }
+            ],
+            id: null,
+            label: 'System Default',
+            name: 'SYSTEM',
+            objectType: 'Contact'
+        };
+
+        sinon
+            .stub(OrgUtils, 'getAllCompactLayoutsForSObject')
+            .returns(Promise.resolve(allCompactLayouts));
+        sinon
+            .stub(OrgUtils, 'getCompactLayoutForSObject')
+            .returns(Promise.resolve(compactLayout));
+
+        const result =
+            await OrgUtils.getCompactLayoutFieldsForSObject('Contact');
+
+        assert.equal(result, compactLayout.fieldItems);
+    });
+
+    test('Returns Contact compact layout', async () => {
+        // Simplified all compact layout data structure
+        const allCompactLayouts = {
+            defaultCompactLayoutId: '123456789',
+            recordTypeCompactLayoutMappings: [
+                {
+                    available: true,
+                    compactLayoutId: null,
+                    compactLayoutName: 'SYSTEM',
+                    recordTypeId: '012000000000000AAA',
+                    recordTypeName: 'Master',
+                    urls: {
+                        compactLayout:
+                            '/services/data/v59.0/sobjects/Contact/describe/compactLayouts/012000000000000AAA'
+                    }
+                },
+                {
+                    available: true,
+                    compactLayoutId: '123456789',
+                    compactLayoutName: 'Mobile layout',
+                    recordTypeId: '012000000000000BBB',
+                    recordTypeName: 'Contact',
+                    urls: {
+                        compactLayout:
+                            '/services/data/v59.0/sobjects/Contact/describe/compactLayouts/012000000000000BBB'
+                    }
+                }
+            ]
+        };
+
+        // Simplified compact layout data structure
+        const compactLayout = {
+            fieldItems: [
+                {
+                    editableForNew: true,
+                    editableForUpdate: true,
+                    label: 'Name'
+                },
+                {
+                    editableForNew: true,
+                    editableForUpdate: true,
+                    label: 'Title'
+                },
+                {
+                    editableForNew: false,
+                    editableForUpdate: false,
+                    label: 'Contact Owner'
+                }
+            ],
+            id: null,
+            label: 'Mobile layout',
+            name: 'Mobile layout',
+            objectType: 'Contact'
+        };
+
+        sinon
+            .stub(OrgUtils, 'getAllCompactLayoutsForSObject')
+            .returns(Promise.resolve(allCompactLayouts));
+        sinon
+            .stub(OrgUtils, 'getCompactLayoutForSObject')
+            .withArgs('Contact', '012000000000000BBB')
+            .returns(Promise.resolve(compactLayout));
+
+        const result =
+            await OrgUtils.getCompactLayoutFieldsForSObject('Contact');
+
+        assert.equal(result, compactLayout.fieldItems);
+    });
+
     test('Returns list of fields for given sObject', async () => {
         const sobjectFields: FieldType[] = [
             buildField('City', 'string', 'Label'),

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -72,13 +72,13 @@ export class OrgUtils {
         }
     }
 
-    public static async getAllCompactLayoutsForSObject(
+    public static async getCompactLayoutsForSObject(
         sObjectName: string
-    ): Promise<any> {
+    ): Promise<Object> {
         const org = await Org.create();
         const conn = org.getConnection();
 
-        const result = await conn.request(
+        const result = await conn.request<Object>(
             `/services/data/v59.0/sobjects/${sObjectName}/describe/compactLayouts`
         );
 
@@ -88,11 +88,11 @@ export class OrgUtils {
     public static async getCompactLayoutForSObject(
         sObjectName: string,
         recordTypeId: string
-    ): Promise<any> {
+    ): Promise<Object> {
         const org = await Org.create();
         const conn = org.getConnection();
 
-        const result = await conn.request(
+        const result = await conn.request<Object>(
             `/services/data/v59.0/sobjects/${sObjectName}/describe/compactLayouts/${recordTypeId}`
         );
 
@@ -106,21 +106,16 @@ export class OrgUtils {
             const fields: CompactLayoutField[] = [];
 
             // Get all the compact layouts associated to this sObject first
-            let result = await this.getAllCompactLayoutsForSObject(sObjectName);
+            let result = await this.getCompactLayoutsForSObject(sObjectName);
 
             if (result) {
-                const resultObj = result as Object;
-
                 // sObject can have multiple compact layouts associated with it. Get the default.
                 const defaultCompactLayoutId =
-                    resultObj['defaultCompactLayoutId' as keyof Object];
+                    result['defaultCompactLayoutId' as keyof Object];
 
                 // Mapping tab
-                console.error(resultObj);
                 const recordTypeCompactLayoutMappings =
-                    resultObj[
-                        'recordTypeCompactLayoutMappings' as keyof Object
-                    ];
+                    result['recordTypeCompactLayoutMappings' as keyof Object];
 
                 // ID of compact layout need to be normalized
                 const recordTypeCompactLayoutMapping = (

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -129,7 +129,8 @@ export class OrgUtils {
                 result['defaultCompactLayoutId'];
 
                 // Mapping table
-                const recordTypeCompactLayoutMappings = result.recordTypeCompactLayoutMappings;
+                const recordTypeCompactLayoutMappings =
+                    result.recordTypeCompactLayoutMappings;
 
                 // ID of compact layout need to be normalized
                 const recordTypeCompactLayoutMapping =

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -72,7 +72,7 @@ export class OrgUtils {
         }
     }
 
-    private static async getAllCompactLayoutsForSObject(
+    public static async getAllCompactLayoutsForSObject(
         sObjectName: string
     ): Promise<any> {
         const org = await Org.create();
@@ -85,7 +85,7 @@ export class OrgUtils {
         return Promise.resolve(result);
     }
 
-    private static async getCompactLayoutForSObject(
+    public static async getCompactLayoutForSObject(
         sObjectName: string,
         recordTypeId: string
     ): Promise<any> {
@@ -103,10 +103,10 @@ export class OrgUtils {
         sObjectName: string
     ): Promise<CompactLayoutField[]> {
         try {
+            const fields: CompactLayoutField[] = [];
+
             // Get all the compact layouts associated to this sObject first
             let result = await this.getAllCompactLayoutsForSObject(sObjectName);
-
-            const fields: CompactLayoutField[] = [];
 
             if (result) {
                 const resultObj = result as Object;
@@ -116,6 +116,7 @@ export class OrgUtils {
                     resultObj['defaultCompactLayoutId' as keyof Object];
 
                 // Mapping tab
+                console.error(resultObj);
                 const recordTypeCompactLayoutMappings =
                     resultObj[
                         'recordTypeCompactLayoutMappings' as keyof Object


### PR DESCRIPTION
To get a compact layout for a sObject I am using 2-pass process.

If sObject has compact layout assigned it will have `defaultCompactLayoutId` assigned. Otherwise, `null` is assigned and in that case the compact layout is defaults to `SYSTEM` compact layout.

After determining which compact layout is actually needed only after that a second network request need to be made in order to get the actual layout content.