### PR TITLE
Getting Org connection from Salesforce Extensions services

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "activationEvents": [
     "onStartupFinished"
   ],
+  "extensionDependencies": [
+    "salesforce.salesforcedx-vscode-core"
+  ],
   "main": "./out/extension.js",
   "l10n": "./l10n",
   "contributes": {

--- a/src/commands/wizard/deployToOrgCommand.ts
+++ b/src/commands/wizard/deployToOrgCommand.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import path = require('path');
+import * as path from 'path';
 import { Uri, commands, window, workspace, l10n } from 'vscode';
 
 export class DeployToOrgCommand {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,8 +9,23 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import * as onboardingWizard from './commands/wizard/onboardingWizard';
+import { CoreExtensionService } from './services/CoreExtensionService';
 
 export function activate(context: vscode.ExtensionContext) {
+    // We need to do this first in case any other services need access to those provided by the core extension
+    try {
+        CoreExtensionService.loadDependencies();
+    } catch (err) {
+        console.error(err);
+        vscode.window.showErrorMessage(
+            vscode.l10n.t(
+                'Failed to activate the extension! Could not load required services from the Salesforce Extension Pack: {0}',
+                (err as Error).message
+            )
+        );
+        return;
+    }
+
     onboardingWizard.registerCommand(context);
     onboardingWizard.onActivate(context);
 }

--- a/src/services/CoreExtensionService.ts
+++ b/src/services/CoreExtensionService.ts
@@ -7,10 +7,7 @@
 
 import { extensions } from 'vscode';
 import { satisfies, valid } from 'semver';
-import type {
-    CoreExtensionApi,
-    WorkspaceContext
-} from '../types';
+import type { CoreExtensionApi, WorkspaceContext } from '../types';
 import {
     CORE_EXTENSION_ID,
     MINIMUM_REQUIRED_VERSION_CORE_EXTENSION

--- a/src/services/CoreExtensionService.ts
+++ b/src/services/CoreExtensionService.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { extensions } from 'vscode';
+import { satisfies, valid } from 'semver';
+import type {
+    CoreExtensionApi,
+    WorkspaceContext
+} from '../types';
+import {
+    CORE_EXTENSION_ID,
+    MINIMUM_REQUIRED_VERSION_CORE_EXTENSION
+} from '../utils/constants';
+
+const NOT_INITIALIZED_ERROR = 'CoreExtensionService not initialized';
+const CORE_EXTENSION_NOT_FOUND = 'Core extension not found';
+const WORKSPACE_CONTEXT_NOT_FOUND = 'Workspace Context not found';
+const coreExtensionMinRequiredVersionError =
+    'You are running an older version of the Salesforce CLI Integration VSCode Extension. Please update the Salesforce Extension pack and try again.';
+
+export class CoreExtensionService {
+    private static initialized = false;
+    private static workspaceContext: WorkspaceContext;
+
+    static loadDependencies() {
+        if (!CoreExtensionService.initialized) {
+            const coreExtension = extensions.getExtension(CORE_EXTENSION_ID);
+            if (!coreExtension) {
+                throw new Error(CORE_EXTENSION_NOT_FOUND);
+            }
+            const coreExtensionVersion = coreExtension.packageJSON.version;
+            if (
+                !CoreExtensionService.isAboveMinimumRequiredVersion(
+                    MINIMUM_REQUIRED_VERSION_CORE_EXTENSION,
+                    coreExtensionVersion
+                )
+            ) {
+                throw new Error(coreExtensionMinRequiredVersionError);
+            }
+
+            const coreExtensionApi = coreExtension.exports as CoreExtensionApi;
+
+            CoreExtensionService.initializeWorkspaceContext(
+                coreExtensionApi?.services.WorkspaceContext
+            );
+
+            CoreExtensionService.initialized = true;
+        }
+    }
+
+    private static initializeWorkspaceContext(
+        workspaceContext: WorkspaceContext | undefined
+    ) {
+        if (!workspaceContext) {
+            throw new Error(WORKSPACE_CONTEXT_NOT_FOUND);
+        }
+        CoreExtensionService.workspaceContext =
+            workspaceContext.getInstance(false);
+    }
+
+    private static isAboveMinimumRequiredVersion(
+        minRequiredVersion: string,
+        actualVersion: string
+    ) {
+        // Check to see if version is in the expected MAJOR.MINOR.PATCH format
+        if (!valid(actualVersion)) {
+            console.debug(
+                'Invalid version format found for the Core Extension.' +
+                    `\nActual version: ${actualVersion}` +
+                    `\nMinimum required version: ${minRequiredVersion}`
+            );
+        }
+        return satisfies(actualVersion, '>=' + minRequiredVersion);
+    }
+
+    static getWorkspaceContext(): WorkspaceContext {
+        if (CoreExtensionService.initialized) {
+            return CoreExtensionService.workspaceContext;
+        }
+        throw new Error(NOT_INITIALIZED_ERROR);
+    }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+export * from './CoreExtensionService';

--- a/src/test/TestHelper.ts
+++ b/src/test/TestHelper.ts
@@ -10,7 +10,7 @@ import { mkdtemp, rm, stat } from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import * as process from 'process';
-import sinon = require('sinon');
+import * as sinon from 'sinon';
 import { WorkspaceUtils } from '../utils/workspaceUtils';
 
 export class TempProjectDirManager {

--- a/src/test/TestHelper.ts
+++ b/src/test/TestHelper.ts
@@ -10,6 +10,8 @@ import { mkdtemp, rm, stat } from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import * as process from 'process';
+import sinon = require('sinon');
+import { WorkspaceUtils } from '../utils/workspaceUtils';
 
 export class TempProjectDirManager {
     readonly projectDir: string;
@@ -64,4 +66,14 @@ export function createPlatformAbsolutePath(...pathArgs: string[]): string {
         absPath = firstChar + absPath.slice(1);
     }
     return absPath;
+}
+
+// Create a stub of WorkspaceUtis.getWorkspaceDir() that returns a path to
+// a temporary directory.
+export function setupTempWorkspaceDirectoryStub(
+    projectDirManager: TempProjectDirManager
+): sinon.SinonStub<[], string> {
+    const getWorkspaceDirStub = sinon.stub(WorkspaceUtils, 'getWorkspaceDir');
+    getWorkspaceDirStub.returns(projectDirManager.projectDir);
+    return getWorkspaceDirStub;
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -42,11 +42,7 @@ async function main() {
         // extension. Bail if there's an error.
         const installExtensionDepsOuput = spawnSync(
             cliPath,
-            [
-                ...args,
-                '--install-extension',
-                CORE_EXTENSION_ID
-            ],
+            [...args, '--install-extension', CORE_EXTENSION_ID],
             { stdio: 'inherit', encoding: 'utf-8' }
         );
         if (installExtensionDepsOuput.error) {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -7,7 +7,13 @@
 
 import * as path from 'path';
 
-import { runTests } from '@vscode/test-electron';
+import {
+    downloadAndUnzipVSCode,
+    resolveCliArgsFromVSCodeExecutablePath,
+    runTests
+} from '@vscode/test-electron';
+import { spawnSync } from 'child_process';
+import { CORE_EXTENSION_ID } from '../utils/constants';
 
 async function main() {
     try {
@@ -24,8 +30,46 @@ async function main() {
             process.env['CODE_COVERAGE'] = '1';
         }
 
-        // Download VS Code, unzip it and run the integration test
-        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+        // Download VS Code, unzip it and run the integration tests.
+        // NB: We'll use the 'stable' version of VSCode for tests, to catch
+        // potential incompatibilities in newer versions than the minmum we
+        // support in the `engines` section of our package.
+        const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
+        const [cliPath, ...args] =
+            resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+
+        // Install the Salesforce Extensions, which is a pre-req for our
+        // extension. Bail if there's an error.
+        const installExtensionDepsOuput = spawnSync(
+            cliPath,
+            [
+                ...args,
+                '--install-extension',
+                CORE_EXTENSION_ID
+            ],
+            { stdio: 'inherit', encoding: 'utf-8' }
+        );
+        if (installExtensionDepsOuput.error) {
+            console.error(
+                `Error installing Salesforce Extensions in test: ${installExtensionDepsOuput.error.message}`
+            );
+            throw installExtensionDepsOuput.error;
+        }
+        if (
+            installExtensionDepsOuput.status &&
+            installExtensionDepsOuput.status !== 0
+        ) {
+            const installNonZeroError = `Install of Salesforce Extensions finished with status ${installExtensionDepsOuput.status}. See console output for more information.`;
+            console.error(installNonZeroError);
+            throw new Error(installNonZeroError);
+        }
+
+        // All clear! Should be able to run the tests.
+        await runTests({
+            extensionDevelopmentPath,
+            extensionTestsPath,
+            vscodeExecutablePath
+        });
     } catch (err) {
         console.error('Failed to run tests', err);
         process.exit(1);

--- a/src/test/suite/utils/uiUtils.test.ts
+++ b/src/test/suite/utils/uiUtils.test.ts
@@ -9,7 +9,7 @@ import * as assert from 'assert';
 import { UIUtils } from '../../../utils/uiUtils';
 import { QuickPickItem, window, QuickPick } from 'vscode';
 import { afterEach, beforeEach } from 'mocha';
-import sinon = require('sinon');
+import * as sinon from 'sinon';
 
 suite('UIUtils Test Suite', () => {
     beforeEach(function () {});

--- a/src/test/suite/utils/workspaceUtils.test.ts
+++ b/src/test/suite/utils/workspaceUtils.test.ts
@@ -18,7 +18,7 @@ import {
     setupTempWorkspaceDirectoryStub
 } from '../../TestHelper';
 import { afterEach, beforeEach } from 'mocha';
-import sinon = require('sinon');
+import * as sinon from 'sinon';
 
 suite('Workspace Test Suite', () => {
     let getWorkspaceDirStub: sinon.SinonStub<[], string>;

--- a/src/types/AuthFields.ts
+++ b/src/types/AuthFields.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export type AuthFields = {
+    accessToken?: string;
+    alias?: string;
+    authCode?: string;
+    clientId?: string;
+    clientSecret?: string;
+    created?: string;
+    createdOrgInstance?: string;
+    devHubUsername?: string;
+    instanceUrl?: string;
+    instanceApiVersion?: string;
+    instanceApiVersionLastRetrieved?: string;
+    isDevHub?: boolean;
+    loginUrl?: string;
+    orgId?: string;
+    password?: string;
+    privateKey?: string;
+    refreshToken?: string;
+    scratchAdminUsername?: string;
+    snapshot?: string;
+    userId?: string;
+    username?: string;
+    usernames?: string[];
+    userProfileName?: string;
+    expirationDate?: string;
+    tracksSource?: boolean;
+};

--- a/src/types/CoreExtensionApi.ts
+++ b/src/types/CoreExtensionApi.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { WorkspaceContext } from './WorkspaceContext';
+
+export interface CoreExtensionApi {
+    services: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        WorkspaceContext: WorkspaceContext;
+    };
+}

--- a/src/types/SingleRecordQueryOptions.ts
+++ b/src/types/SingleRecordQueryOptions.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export interface SingleRecordQueryOptions {
+    tooling?: boolean;
+    returnChoicesOnMultiple?: boolean;
+    choiceField?: string;
+}

--- a/src/types/WorkspaceContext.ts
+++ b/src/types/WorkspaceContext.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { Connection } from '@salesforce/core';
+import { Event } from 'vscode';
+
+export interface WorkspaceContext {
+    readonly onOrgChange: Event<{
+        username?: string;
+        alias?: string;
+    }>;
+    getInstance(forceNew: boolean): WorkspaceContext;
+    getConnection(): Promise<Connection>;
+    username(): string | undefined;
+    alias(): string | undefined;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+export * from './AuthFields';
+export * from './CoreExtensionApi';
+export * from './SingleRecordQueryOptions';
+export * from './WorkspaceContext';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export const MINIMUM_REQUIRED_VERSION_CORE_EXTENSION = '58.4.1';
+export const CORE_EXTENSION_ID = 'salesforce.salesforcedx-vscode-core';

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -5,7 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { ConfigAggregator, Org, OrgConfigProperties } from '@salesforce/core';
+import { ConfigAggregator, OrgConfigProperties } from '@salesforce/core';
+import { CoreExtensionService } from '../services/CoreExtensionService';
 
 export interface SObject {
     apiName: string;
@@ -48,8 +49,8 @@ export type SObjectCompactLayout = {
 export class OrgUtils {
     public static async getSobjects(): Promise<SObject[]> {
         try {
-            const org = await Org.create();
-            const conn = org.getConnection();
+            const conn =
+                await CoreExtensionService.getWorkspaceContext().getConnection();
             const result = await conn.describeGlobal();
 
             const sobjects = result.sobjects
@@ -71,8 +72,8 @@ export class OrgUtils {
 
     public static async getFieldsForSObject(apiName: string): Promise<Field[]> {
         try {
-            const org = await Org.create();
-            const conn = org.getConnection();
+            const conn =
+                await CoreExtensionService.getWorkspaceContext().getConnection();
             const result = await conn.describe(apiName);
 
             const fields = result.fields
@@ -95,9 +96,13 @@ export class OrgUtils {
     public static async getCompactLayoutsForSObject(
         sObjectName: string
     ): Promise<SObjectCompactLayouts> {
-        const org = await Org.create();
-        const conn = org.getConnection();
+        const conn =
+            await CoreExtensionService.getWorkspaceContext().getConnection();
 
+        // TODO: We should probably tack to an approach that uses the underlying
+        // `jsforce` functions for getting compact layouts. For example, something
+        // based on
+        // https://github.com/jsforce/jsforce/blob/c04515846e91f84affa4eb87a7b2adb1f58bf04d/lib/sobject.js#L441-L444
         const result = await conn.request<SObjectCompactLayouts>(
             `/services/data/v59.0/sobjects/${sObjectName}/describe/compactLayouts`
         );
@@ -109,9 +114,8 @@ export class OrgUtils {
         sObjectName: string,
         recordTypeId: string
     ): Promise<SObjectCompactLayout> {
-        const org = await Org.create();
-        const conn = org.getConnection();
-
+        const conn =
+            await CoreExtensionService.getWorkspaceContext().getConnection();
         const result = await conn.request<SObjectCompactLayout>(
             `/services/data/v59.0/sobjects/${sObjectName}/describe/compactLayouts/${recordTypeId}`
         );


### PR DESCRIPTION
This PR tacks to a design pattern recommended by the Salesforce Extensions team, for consuming the services that their extension exports for Org-based administration, connections, etc. With the previous implementation, we weren't successfully able to bootstrap a connection to the user's default Org, for retrieving sObject metadata.