### PR TITLE
Attempting to patch VSCode tests issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1913,9 +1913,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.6.tgz",
-      "integrity": "sha512-M31xGH0RgqNU6CZ4/9g39oUMJ99nLzfjA+4UbtIQ6TcXQ6+2qkjOOxedmPBDDCg26/3Al5ubjY80hIoaMwKYSw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -15,12 +15,7 @@ import {
 import { spawnSync } from 'child_process';
 import { CORE_EXTENSION_ID } from '../utils/constants';
 
-// There's a known issue (https://github.com/microsoft/vscode/issues/200895)
-// with VSCode 1.85.1 and running tests on Windows. We'll stick with an
-// explicit working version for now. TODO: change this back to 'stable' when
-// the problem is resolved.
-// const VSCODE_VERSION = 'stable';
-const VSCODE_TEST_VERSION = '1.84.2';
+const VSCODE_TEST_VERSION = 'stable';
 
 async function main() {
     try {


### PR DESCRIPTION
[Sounds like](https://github.com/microsoft/vscode/issues/200895#issuecomment-1857280064) a bump in the `@vscode/test-electron` dependency may fix the Windows test issue we saw in https://github.com/salesforce/salesforcedx-vscode-mobile/pull/57. Giving it a whirl.