### PR TITLE
Additionally publish to Open VSX

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -109,5 +109,7 @@ jobs:
             - name: Publish to VSCode Marketplace
               env:
                   VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
+                  OPEN_VSX_PERSONAL_ACCESS_TOKEN: ${{ secrets.OPEN_VSX_PERSONAL_ACCESS_TOKEN }}
               run: |
                   npx vsce publish -p ${{ env.VSCE_PERSONAL_ACCESS_TOKEN }} --packagePath ${{ steps.get_package_name.outputs.result }}
+                  npx ovsx publish ${{ steps.get_package_name.outputs.result }} -p ${{ env.OPEN_VSX_PERSONAL_ACCESS_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "glob": "^8.1.0",
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
+        "ovsx": "^0.8.4",
         "prettier": "^3.0.3",
         "rimraf": "^5.0.5",
         "sinon": "^17.0.0",
@@ -2670,6 +2671,12 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -3872,6 +3879,26 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -4483,6 +4510,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-docker": {
@@ -6294,6 +6333,27 @@
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ovsx": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.8.4.tgz",
+      "integrity": "sha512-RMtGSVNM4NWSF9uVWCUqaYiA7ID8Vqm/rSk2W37eYVrDLOI/3do2IRY7rQYkvJqb6sS6LAnALODBkD50tIM1kw==",
+      "dev": true,
+      "dependencies": {
+        "@vscode/vsce": "^2.19.0",
+        "commander": "^6.1.0",
+        "follow-redirects": "^1.14.6",
+        "is-ci": "^2.0.0",
+        "leven": "^3.1.0",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.1"
+      },
+      "bin": {
+        "ovsx": "lib/ovsx"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
     "sinon": "^17.0.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "ovsx": "^0.8.4"
   },
   "dependencies": {
     "@salesforce/core": "^5.3.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "salesforcedx-vscode-mobile",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.2.0",
+  "version": "0.3.0-beta1",
   "publisher": "salesforce",
   "engines": {
     "vscode": "^1.77.0",


### PR DESCRIPTION
Does what it says on the tin. Not sure if we want to also bump the patch version and publish a release for these changes or not? But otherwise, hopefully the updates are fairly self explanatory. Open VSX publishing implemented per their [documentation](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions).