### PR TITLE
Telling VSCode that Prettier is the default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    // Prettier is this project's code formatter.
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -38,15 +38,16 @@ async function main() {
         // support in the `engines` section of our package.
         const vscodeExecutablePath =
             await downloadAndUnzipVSCode(VSCODE_TEST_VERSION);
-        const [cliPath, ...args] =
+        const [cliPath, ...cliArgs] =
             resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
         // Install the Salesforce Extensions, which is a pre-req for our
         // extension. Bail if there's an error.
+        const isWindows = process.platform === 'win32';
         const installExtensionDepsOuput = spawnSync(
-            cliPath,
-            [...args, '--install-extension', CORE_EXTENSION_ID],
-            { stdio: 'inherit', encoding: 'utf-8' }
+            isWindows ? `"${cliPath}"` : cliPath,
+            [...cliArgs, '--install-extension', CORE_EXTENSION_ID],
+            { stdio: 'inherit', encoding: 'utf-8', shell: isWindows }
         );
         if (installExtensionDepsOuput.error) {
             console.error(


### PR DESCRIPTION
Just helps keep VSCode formatting synced up with what we align to in our Node project.