### PR TITLE
chore: simplify diagnostic counting

### DIFF
--- a/lsp/server/src/test/validateGraphql.spec.ts
+++ b/lsp/server/src/test/validateGraphql.spec.ts
@@ -38,7 +38,6 @@ describe('validateGraphql', () => {
             };
             `
         );
-        //const diagnostics = await validateGraphql(textDocument, 100);
         const diagnostics = await validateGraphql(textDocument);
     
         assert.equal(diagnostics.length, 1);

--- a/lsp/server/src/test/validateGraphql.spec.ts
+++ b/lsp/server/src/test/validateGraphql.spec.ts
@@ -38,7 +38,8 @@ describe('validateGraphql', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        //const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql(textDocument);
     
         assert.equal(diagnostics.length, 1);
         assert.equal(diagnostics[0].message, 'uiapi is misspelled.');
@@ -59,7 +60,7 @@ describe('validateGraphql', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql(textDocument);
     
         assert.equal(diagnostics.length, 0);
     });

--- a/lsp/server/src/test/validateGraphql.test.ts
+++ b/lsp/server/src/test/validateGraphql.test.ts
@@ -38,7 +38,7 @@ suite('Diagnostics Test Suite - Server - Validate GraphQL', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql(textDocument);
 
         assert.equal(diagnostics.length, 1);
         assert.equal(diagnostics[0].message, 'uiapi is misspelled.');
@@ -59,7 +59,7 @@ suite('Diagnostics Test Suite - Server - Validate GraphQL', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql(textDocument);
 
         assert.equal(diagnostics.length, 0);
     });

--- a/lsp/server/src/test/validateJs.test.ts
+++ b/lsp/server/src/test/validateJs.test.ts
@@ -37,7 +37,7 @@ suite('Diagnostics Test Suite - Server - Validate JS', () => {
             }
          `
         );
-        const diagnostics = await validateJs(textDocument, 100);
+        const diagnostics = await validateJs(textDocument);
 
         assert.equal(diagnostics.length, 1);
         assert.equal(diagnostics[0].message, LOCAL_CHANGE_NOT_AWARE_MESSAGE);
@@ -52,7 +52,7 @@ suite('Diagnostics Test Suite - Server - Validate JS', () => {
              var var i = 100;
             `
         );
-        const diagnostics = await validateJs(textDocument, 100);
+        const diagnostics = await validateJs(textDocument);
 
         assert.equal(diagnostics.length, 0);
     });

--- a/lsp/server/src/validateDocument.ts
+++ b/lsp/server/src/validateDocument.ts
@@ -28,22 +28,17 @@ export async function validateDocument(
     const { uri } = document;
 
     const setting = await getDocumentSettings(uri);
-    const results: Diagnostic[] = [];
+    let results: Diagnostic[] = [];
 
     if (document.languageId === 'javascript') {
         // handles JS rules
-        const jsDiagnostics = await validateJs(
-            document,
-            setting.maxNumberOfProblems - results.length
-        );
-        results.push(...jsDiagnostics);
-
+        const jsDiagnostics = await validateJs(document);
+        
         // handle graphql rules
-        const graphqlDiagnostics = await validateGraphql(
-            document,
-            setting.maxNumberOfProblems - results.length
-        );
-        results.push(...graphqlDiagnostics);
+        const graphqlDiagnostics = await validateGraphql(document);
+
+        results = results.concat(jsDiagnostics, graphqlDiagnostics);
+        results.splice(setting.maxNumberOfProblems);
     }
 
     if (document.languageId === 'html') {


### PR DESCRIPTION
### What does this PR do?
Diagnostics count threshold was checked per validator. Also, similar code pattern of doing the math for calculating threshold was implicitly required for future validators to be added.

So instead, making validators do what they are made for. Validate. Checking for maximum count of diagnostic threshold is moved up to the caller. This makes code read simpler and validator to do it's single responsibility.

This change does not incur a hit in performance as diagnostics previously had always been queried for. 

### What issues does this PR fix or reference?
