### PR TITLE
Always delete tsconfig.tsbuildinfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     "scripts": {
         "clean": "rimraf out ./lsp/server/out ./lsp/client/out",
-        "compile": "tsc -b ./",
+        "compile": "rimraf ./lsp/server/tsconfig.tsbuildinfo ./lsp/client/tsconfig.tsbuildinfo && tsc -b ./",
         "watch": "tsc -watch -b ./",
         "pretest": "npm run compile && npm run lint",
         "lint": "eslint src --ext ts",


### PR DESCRIPTION
### What does this PR do?
By always deleting tsconfig.tsbuildinfo ahead of `tsc` we force new builds for LSP client and server

### What issues does this PR fix or reference?
