### PR TITLE
Utilize workspace settings and code action to let developer configure or suppress diagnostics.

### DIFF
--- a/lsp/server/src/diagnostic/DiagnosticProducer.ts
+++ b/lsp/server/src/diagnostic/DiagnosticProducer.ts
@@ -7,8 +7,15 @@
 
 import { Diagnostic } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { DiagnosticId } from './DiagnosticSettings';
 
 export interface DiagnosticProducer<T> {
+
+    /**
+     * Get the Id for the diagnostic producer. 
+     */
+    getId(): DiagnosticId;
+
     /**
      * Validate the parsed text document as astNode and return a list of diagnostics.
      * @param textDocument the language server text document
@@ -19,4 +26,9 @@ export interface DiagnosticProducer<T> {
         textDocument: TextDocument,
         astNode: T
     ): Promise<Diagnostic[]>;
+
+}
+
+export interface DiagnosticMetaData {
+    id: DiagnosticId
 }

--- a/lsp/server/src/diagnostic/DiagnosticSettings.ts
+++ b/lsp/server/src/diagnostic/DiagnosticSettings.ts
@@ -1,0 +1,57 @@
+    /*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export type DiagnosticId = 
+    | 'missspelled-uiapi' 
+    | 'adapters-local-change-not-aware'; 
+
+/**
+ * data structure for diagnostic suppression configuration.
+ */
+export type DiagnosticSettings = {
+    maxNumberOfProblems: number;
+    suppressAll?: boolean;
+    suppressedRuleIds?: Set<DiagnosticId>
+}
+
+/**
+ * Check if the individual diagnostic should be suppressed.
+ * @param settings The suppression config
+ * @param id The configuration id to check.
+ * @returns True if suppressed.
+ */
+export function isTheDiagnosticSuppressed(settings: DiagnosticSettings, id: DiagnosticId) {
+    return settings.suppressAll === true || settings.suppressedRuleIds?.has(id);
+}
+
+export const defaultDiagnosticSettings: DiagnosticSettings = {
+    maxNumberOfProblems: 1000
+}
+
+/**
+ * Take in input, possibly a diagnostic json setting true and get valid settings 
+ * @param input the input, a well format tree is like 
+ * 
+ *  {
+            "suppress.all": true,
+            "suppressed.rule.Ids": ["adapters-local-change-not-aware"],
+            "maxProblemNumber": 50
+    }
+ * 
+ * @returns 
+ */
+export function getSettings(input: any): DiagnosticSettings {
+    const maxNumberOfProblems = parseInt(input['maxProblemNumber']);
+    const suppressAll = input['suppress.all'] === true || input['suppress.all'] === true;
+    const inputIdArray = input['suppressed.rule.Ids'];
+    const suppressedRuleIds = inputIdArray instanceof Array? new Set(inputIdArray): new Set();
+    return {
+        maxNumberOfProblems: isNaN(maxNumberOfProblems)?defaultDiagnosticSettings.maxNumberOfProblems:maxNumberOfProblems,
+        suppressAll,
+        suppressedRuleIds
+    };
+}

--- a/lsp/server/src/diagnostic/gql/misspelled-uiapi.ts
+++ b/lsp/server/src/diagnostic/gql/misspelled-uiapi.ts
@@ -9,6 +9,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DiagnosticProducer } from '../DiagnosticProducer';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
 import { ASTNode, visit } from 'graphql';
+import { DiagnosticId } from '../DiagnosticSettings';
 
 const LOCAL_CHANGE_NOT_AWARE_MESSAGE = 'uiapi is misspelled.';
 const SEVERITY = DiagnosticSeverity.Error;
@@ -19,6 +20,10 @@ const SEVERITY = DiagnosticSeverity.Error;
 */
 export class MisspelledUiapi implements DiagnosticProducer<ASTNode> {
    
+    getId(): DiagnosticId {
+        return 'missspelled-uiapi' ;
+    }
+
     validateDocument(
         textDocument: TextDocument,
         rootNode: ASTNode

--- a/lsp/server/src/diagnostic/js/adapters-local-change-not-aware.ts
+++ b/lsp/server/src/diagnostic/js/adapters-local-change-not-aware.ts
@@ -10,6 +10,7 @@ import traverse from '@babel/traverse';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DiagnosticProducer } from '../DiagnosticProducer';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
+import { DiagnosticId } from '../DiagnosticSettings';
 
 export const LOCAL_CHANGE_NOT_AWARE_MESSAGE =
     'The wire adapter you are using allows you to work offline, but it does not automatically update its records when data is added or removed while you are disconnected.';
@@ -24,6 +25,11 @@ const LOCAL_CHANGE_NOT_AWARE_ADAPTERS: string[] = [
  * Produce diagnostics for adapter which works offline but doesn't handle local change.
  */
 export class AdaptersLocalChangeNotAware implements DiagnosticProducer<Node> {
+    
+    getId(): DiagnosticId {
+        return 'missspelled-uiapi' ;
+    }
+
     validateDocument(
         textDocument: TextDocument,
         node: Node

--- a/lsp/server/src/server.ts
+++ b/lsp/server/src/server.ts
@@ -14,11 +14,17 @@ import {
     TextDocumentSyncKind,
     InitializeResult,
     DocumentDiagnosticReportKind,
-    type DocumentDiagnosticReport
+    type DocumentDiagnosticReport,
+    CodeAction,
+    CodeActionKind,
+    WorkspaceChange,
 } from 'vscode-languageserver/node';
+
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { validateDocument } from './validateDocument';
+import { globalSettings, Settings, getSettings} from './settings';
+import { DiagnosticMetaData } from './diagnostic/DiagnosticProducer';
 
 // Create a connection for the server, using Node's IPC as a transport.
 const connection = createConnection(ProposedFeatures.all);
@@ -31,9 +37,13 @@ let hasWorkspaceFolderCapability = false;
 export let hasDiagnosticRelatedInformationCapability = false;
 
 let extensionName: string = '';
+let workspaceFolder: string | null | undefined;
+
+const documentCache: Map<string, TextDocument> = new Map;
 
 connection.onInitialize((params: InitializeParams) => {
     extensionName = params.initializationOptions?.extensionName;
+    workspaceFolder = params.workspaceFolders && params.workspaceFolders[0].uri;
     const capabilities = params.capabilities;
 
     // Does the client support the `workspace/configuration` request?
@@ -56,7 +66,8 @@ connection.onInitialize((params: InitializeParams) => {
             diagnosticProvider: {
                 interFileDependencies: false,
                 workspaceDiagnostics: false
-            }
+            },
+            codeActionProvider: true,
         }
     };
 
@@ -67,15 +78,15 @@ connection.onInitialize((params: InitializeParams) => {
             }
         };
     }
+
     return result;
 });
 
 connection.onInitialized(() => {
     if (hasConfigurationCapability) {
-        // Register for all configuration changes.
+        // Register for configuration change at 'mobile.lsp' section.
         connection.client.register(
-            DidChangeConfigurationNotification.type,
-            undefined
+            DidChangeConfigurationNotification.type, { section: 'mobile.lsp' }
         );
     }
     if (hasWorkspaceFolderCapability) {
@@ -85,57 +96,16 @@ connection.onInitialized(() => {
     }
 });
 
-// Settings for Mobile LSP
-export interface MobileSettings {
-    maxNumberOfProblems: number; //max number of diagnostics to detect per document.
-}
-
-// The global settings, used when the `workspace/configuration` request is not supported by the client.
-// Please note that this is not the case when using this server with the client provided
-// but could happen with other clients.
-const defaultSettings: MobileSettings = { maxNumberOfProblems: 1000 };
-let globalSettings: MobileSettings = defaultSettings;
-
-// Cache the settings of all open documents
-const documentSettings: Map<string, MobileSettings> = new Map();
+// Cache the settings
+let settings: Settings = globalSettings
 
 connection.onDidChangeConfiguration((change) => {
-    if (hasConfigurationCapability) {
-        // Reset all cached document settings
-        documentSettings.clear();
-    } else {
-        globalSettings = <MobileSettings>(
-            (change.settings.mobileLSP || defaultSettings)
-        );
-    }
+    settings = hasConfigurationCapability? getSettings(change.settings['mobile']['lsp']): globalSettings;
+
     // Refresh the diagnostics since the `maxNumberOfProblems` could have changed.
     // We could optimize things here and re-fetch the setting first can compare it
     // to the existing setting, but this is out of scope for this example.
     connection.languages.diagnostics.refresh();
-});
-
-export async function getDocumentSettings(
-    resource: string
-): Promise<MobileSettings> {
-    if (!hasConfigurationCapability) {
-        return Promise.resolve(globalSettings);
-    }
-    let result = documentSettings.get(resource);
-    if (!result) {
-        result = await connection.workspace.getConfiguration({
-            scopeUri: resource,
-            section: 'mobileLSP'
-        });
-        result = result || defaultSettings;
-        documentSettings.set(resource, result);
-    }
-    return result;
-}
-
-// Only keep settings for open documents
-documents.onDidClose((e) => {
-    const uri = e.document.uri;
-    documentSettings.delete(uri);
 });
 
 connection.languages.diagnostics.on(async (params) => {
@@ -143,7 +113,8 @@ connection.languages.diagnostics.on(async (params) => {
     if (document !== undefined) {
         return {
             kind: DocumentDiagnosticReportKind.Full,
-            items: await validateDocument(document, extensionName)
+            // items: await validateDocument(settings.diagnostic, document, extensionName)
+            items: await validateDocument(settings.diagnostic, document, extensionName)
         } satisfies DocumentDiagnosticReport;
     } else {
         // We don't know the document. We can either try to read it from disk
@@ -153,6 +124,63 @@ connection.languages.diagnostics.on(async (params) => {
             items: []
         } satisfies DocumentDiagnosticReport;
     }
+});
+
+connection.onCodeAction((params) => {
+    const textDocument = documentCache.get(params.textDocument.uri);
+    const diagnostics = params.context.diagnostics;
+	if (textDocument === undefined || diagnostics.length === 0) {
+		return undefined;
+	}
+    
+	const result: CodeAction[] = [];
+    diagnostics.forEach((item) => {
+        const { data } = item;
+        if (data !== undefined) {
+            const metData = data as DiagnosticMetaData;
+            if (metData.id !== undefined) {
+
+                // const suppressThisDiagnostic: CodeAction = {
+                //     title: 'Suppress this diagnostic', 
+                //     kind: CodeActionKind.QuickFix,
+                //     diagnostics: [item],
+
+                // };
+                // result.push(suppressThisDiagnostic);
+
+                    const suppressAllDiagnostic: CodeAction = {
+                        title: 'Suppress All Salesforce Mobile diagnostic', 
+                        kind: CodeActionKind.QuickFix,
+                        diagnostics: [item],
+                        command: {
+                            title: 'Update workspace setting',
+                            command: 'salesforce.salesforcedx-vscode-mobile.lsp.updateDiagnosticsSetting',
+                            arguments: [{
+                                'suppress.all': true
+                            }]
+                        }
+                    };
+                    result.push(suppressAllDiagnostic);
+                
+            }
+        }
+    });
+
+
+    return result;
+});
+
+// The content of a text document has changed. This event is emitted
+// when the text document first opened or when its content has changed.
+documents.onDidChangeContent(change => {
+	const document = change.document;
+	documentCache.set(document.uri, document);
+});
+
+// Only keep cache for open documents
+documents.onDidClose(e => {
+	const uri = e.document.uri;
+	documentCache.delete(uri);
 });
 
 // Make the text document manager listen on the connection

--- a/lsp/server/src/settings.ts
+++ b/lsp/server/src/settings.ts
@@ -1,0 +1,36 @@
+
+// Settings for Mobile LSP
+
+import { 
+    defaultDiagnosticSettings, 
+    DiagnosticSettings,
+    getSettings as getDiagnosticSettings
+} from './diagnostic/DiagnosticSettings';
+
+export interface Settings {
+    diagnostic: DiagnosticSettings
+}
+
+// The global settings, used when the `workspace/configuration` request is not supported by the client.
+// Please note that this is not the case when using this server with the client provided
+// but could happen with other clients.
+export const defaultSettings: Settings = { 
+    diagnostic: defaultDiagnosticSettings
+};
+
+export let globalSettings: Settings = defaultSettings;
+
+/**
+ * 
+ * @param input 
+ */
+export function getSettings(input: any): Settings {
+    const diagnosticSetting = getDiagnosticSettings(input["diagnostic"]);
+    return {
+        diagnostic: diagnosticSetting
+    }
+}
+
+
+
+

--- a/lsp/server/src/test/diagnostic/js/adapters-local-change-not-aware.test.ts
+++ b/lsp/server/src/test/diagnostic/js/adapters-local-change-not-aware.test.ts
@@ -30,6 +30,8 @@ export default class RelatedListRecords extends LightningElement {
     fields: ["Opportunity.Name"],
   })
   relatedListHandler({ error, data }) {
+
+  ....
   }
 }
 `;

--- a/lsp/server/src/test/validateDocument.spec.ts
+++ b/lsp/server/src/test/validateDocument.spec.ts
@@ -13,7 +13,7 @@ import { validateDocument } from '../validateDocument';
  * Verify validateDocument calls into js, graphql and html diagnostic rule. 
  */
 describe('validateDocument', () => {
-    
+    const setting = {maxNumberOfProblems: 100};
     it('call in validateGraphql', async () => {
         const textDocument = TextDocument.create(
             'file://test.js',
@@ -42,7 +42,7 @@ describe('validateDocument', () => {
             `
         );
         const source = "xyz";
-        const diagnostics = await validateDocument(textDocument, source);
+        const diagnostics = await validateDocument(setting, textDocument, source);
     
         assert.equal(diagnostics.length, 1);
         const diagnostic = diagnostics[0];

--- a/lsp/server/src/test/validateGraphql.spec.ts
+++ b/lsp/server/src/test/validateGraphql.spec.ts
@@ -10,7 +10,7 @@ import { validateGraphql } from '../validateGraphql';
 import * as assert from 'assert';
 
 describe('validateGraphql', () => {
-    
+    const setting = {maxNumberOfProblems: 100};
     it('valid uiapi missing diagnostic', async () => {
         const textDocument = TextDocument.create(
             'file://test.js',
@@ -38,7 +38,7 @@ describe('validateGraphql', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql(setting, textDocument, 100);
     
         assert.equal(diagnostics.length, 1);
         assert.equal(diagnostics[0].message, 'uiapi is misspelled.');
@@ -59,7 +59,7 @@ describe('validateGraphql', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql(setting, textDocument, 100);
     
         assert.equal(diagnostics.length, 0);
     });

--- a/lsp/server/src/test/validateGraphql.test.ts
+++ b/lsp/server/src/test/validateGraphql.test.ts
@@ -11,6 +11,8 @@ import * as assert from 'assert';
 import { suite, test } from 'mocha';
 
 suite('Diagnostics Test Suite - Server - Validate GraphQL', () => {
+    const setting = {maxNumberOfProblems: 100};
+    
     test('Valid uiapi missing diagnostic', async () => {
         const textDocument = TextDocument.create(
             'file://test.js',
@@ -38,7 +40,7 @@ suite('Diagnostics Test Suite - Server - Validate GraphQL', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql(setting, textDocument, 100);
 
         assert.equal(diagnostics.length, 1);
         assert.equal(diagnostics[0].message, 'uiapi is misspelled.');
@@ -59,7 +61,7 @@ suite('Diagnostics Test Suite - Server - Validate GraphQL', () => {
             };
             `
         );
-        const diagnostics = await validateGraphql(textDocument, 100);
+        const diagnostics = await validateGraphql({maxNumberOfProblems: 100}, textDocument, 100);
 
         assert.equal(diagnostics.length, 0);
     });

--- a/lsp/server/src/test/validateJs.test.ts
+++ b/lsp/server/src/test/validateJs.test.ts
@@ -12,6 +12,7 @@ import { validateJs } from '../validateJs';
 import { LOCAL_CHANGE_NOT_AWARE_MESSAGE } from '../diagnostic/js/adapters-local-change-not-aware';
 
 suite('Diagnostics Test Suite - Server - Validate JS', () => {
+    const setting = {maxNumberOfProblems: 100};
     test('Validate local change not aware adapters', async () => {
         const textDocument = TextDocument.create(
             'file://test.js',
@@ -37,7 +38,7 @@ suite('Diagnostics Test Suite - Server - Validate JS', () => {
             }
          `
         );
-        const diagnostics = await validateJs(textDocument, 100);
+        const diagnostics = await validateJs(setting, textDocument, 100);
 
         assert.equal(diagnostics.length, 1);
         assert.equal(diagnostics[0].message, LOCAL_CHANGE_NOT_AWARE_MESSAGE);
@@ -52,7 +53,7 @@ suite('Diagnostics Test Suite - Server - Validate JS', () => {
              var var i = 100;
             `
         );
-        const diagnostics = await validateJs(textDocument, 100);
+        const diagnostics = await validateJs(setting, textDocument, 100);
 
         assert.equal(diagnostics.length, 0);
     });

--- a/lsp/server/src/validateDocument.ts
+++ b/lsp/server/src/validateDocument.ts
@@ -8,9 +8,9 @@
 import { Diagnostic } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-import { getDocumentSettings } from './server';
 import { validateJs } from './validateJs';
 import { validateGraphql } from './validateGraphql';
+import { DiagnosticSettings } from './diagnostic/DiagnosticSettings';
 
 /**
  * Validate the document based on its extension type.
@@ -22,17 +22,20 @@ import { validateGraphql } from './validateGraphql';
  * @returns Diagnostic results for the document.
  */
 export async function validateDocument(
+    setting: DiagnosticSettings,
     document: TextDocument,
-    extensionName: string
+    extensionName: string, 
 ): Promise<Diagnostic[]> {
     const { uri } = document;
 
-    const setting = await getDocumentSettings(uri);
+ //   const setting = await getDocumentSettings(uri);
+
     const results: Diagnostic[] = [];
 
     if (document.languageId === 'javascript') {
         // handles JS rules
         const jsDiagnostics = await validateJs(
+            setting,
             document,
             setting.maxNumberOfProblems - results.length
         );
@@ -40,6 +43,7 @@ export async function validateDocument(
 
         // handle graphql rules
         const graphqlDiagnostics = await validateGraphql(
+            setting,
             document,
             setting.maxNumberOfProblems - results.length
         );

--- a/lsp/server/src/validateJs.ts
+++ b/lsp/server/src/validateJs.ts
@@ -11,6 +11,7 @@ import { parseJs } from './utils/babelUtil';
 import { Node } from '@babel/types';
 import { DiagnosticProducer } from './diagnostic/DiagnosticProducer';
 import { AdaptersLocalChangeNotAware } from './diagnostic/js/adapters-local-change-not-aware';
+import { DiagnosticSettings, isTheDiagnosticSuppressed } from './diagnostic/DiagnosticSettings';
 
 const jsDiagnosticProducers: DiagnosticProducer<Node>[] = [];
 jsDiagnosticProducers.push(new AdaptersLocalChangeNotAware());
@@ -22,6 +23,7 @@ jsDiagnosticProducers.push(new AdaptersLocalChangeNotAware());
  * @returns An array of diagnostics found within the JavaScript file
  */
 export async function validateJs(
+    setting: DiagnosticSettings,
     textDocument: TextDocument,
     maxCount: number
 ): Promise<Diagnostic[]> {
@@ -30,7 +32,9 @@ export async function validateJs(
         return results;
     }
 
-    if (jsDiagnosticProducers.length > 0) {
+    if (jsDiagnosticProducers.filter((producer) => {
+        return !isTheDiagnosticSuppressed(setting, producer.getId())
+    }).length > 0) {
         try {
             const jsNode = parseJs(textDocument.getText());
             for (const producer of jsDiagnosticProducers) {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,15 @@
                     "type": "string",
                     "default": "^8.47.0",
                     "description": "%extension.commands.salesforce-mobile-offline.eslint.version%"
+                },
+                "salesforce.salesforcedx-vscode-mobile.lsp.diagnostics": {
+                    "type":"object",
+                    "default": {
+                        "suppress.all": false,
+                        "suppressed.rule.Ids": [],
+                        "maxProblemNumber": 200
+                    },
+                    "description": "lsp diagnostics configuration"
                 }
             }
         }

--- a/src/commands/settings/settings.ts
+++ b/src/commands/settings/settings.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import * as vscode from 'vscode';
+
+const extensionId = 'salesforce.salesforcedx-vscode-mobile';
+
+export function registerCommand(context: vscode.ExtensionContext) {
+    context.subscriptions.push(vscode.commands.registerCommand(
+        `${extensionId}.lsp.updateDiagnosticsSetting`,
+        async (diagnosticSetting) => {
+            const config = vscode.workspace.getConfiguration(extensionId);
+            try {
+                await config.update('lsp.diagnostics', diagnosticSetting, vscode.ConfigurationTarget.Workspace);
+            } catch(error) {
+                const i = 100;
+            }
+        }
+    ));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@
 import * as vscode from 'vscode';
 import * as onboardingWizard from './commands/wizard/onboardingWizard';
 import * as configureLintingToolsCommand from './commands/lint/configureLintingToolsCommand';
+import * as settingsCommand from './commands/settings/settings';
 import { CoreExtensionService } from './services/CoreExtensionService';
 import { WorkspaceUtils } from './utils/workspaceUtils';
 import * as lspClient from '../lsp/client/out/extension';
@@ -39,6 +40,8 @@ export function activate(context: vscode.ExtensionContext) {
     onboardingWizard.onActivate(context);
 
     configureLintingToolsCommand.registerCommand(context);
+    settingsCommand.registerCommand(context);
+    
     lspClient.activate(context);
 }
 


### PR DESCRIPTION
We will implement lsp diagnostics, like component offline support checking, graphql or js mobile related ...  Developer needs the capability to suppress them.

This pr does:
- two Code Action quickfix: suppress one type of diagnostics or suppress all lds mobile diagnostic. 
- limit the max diagnostics to return
 
