### PR TITLE
Finalize draft not aware Finalize draft not aware diagnostics for getRelatedListRecords and getRelatedListCount

### DIFF
--- a/lsp/client/src/extension.ts
+++ b/lsp/client/src/extension.ts
@@ -37,10 +37,6 @@ export function activate(
         }
     };
 
-    // Get extension name
-    const extensionTitle =
-        context.extension.packageJSON.contributes.configuration.title;
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         documentSelector: [
@@ -57,7 +53,6 @@ export function activate(
             ]
         },
         initializationOptions: {
-            extensionTitle,
             updateDiagnosticsSettingCommand,
             diagnosticsSettingSection
         }

--- a/lsp/server/src/diagnostic/js/adapters-local-change-not-aware.ts
+++ b/lsp/server/src/diagnostic/js/adapters-local-change-not-aware.ts
@@ -53,9 +53,9 @@ export class AdaptersLocalChangeNotAware implements DiagnosticProducer<Node> {
     ): Promise<Diagnostic[]> {
         const result: Diagnostic[] = [];
 
-        const nodesWithAdapter = this.findLocalChangeNotAwareAdapterNode(node);
+        const nodeInfoMap = this.findLocalChangeNotAwareAdapterNode(node);
 
-        for (let [node, info] of nodesWithAdapter) {
+        for (let [node, info] of nodeInfoMap) {
             const diagnostic: Diagnostic = {
                 severity: SEVERITY,
                 range: {
@@ -77,14 +77,16 @@ export class AdaptersLocalChangeNotAware implements DiagnosticProducer<Node> {
     }
 
     /**
-     * Find a list of adapters which are not draft change aware. For example: getRelatedListRecords from below LWC. 
+     * Find a map of astNode to corresponding diagnostic info for adapters which are not draft change aware. 
+     * For example: getRelatedListRecords from below LWC. 
         export default class RelatedListRecords extends LightningElement {
             ...
             @wire(getRelatedListRecords, 
             ...
         }
      * @param astNode The AST root node for the LWC js file.
-     * @returns A map of node to adapter name which is not draft aware. 
+     * @returns A map where each key is an ASTNode representing an adapter that does not account for specific local changes,
+     * and each value is an Info object containing a message and, optionally, a link with additional context.
      */
     private findLocalChangeNotAwareAdapterNode(astNode: Node): Map<Node, Info> {
         const result = new Map<Node, Info>();

--- a/lsp/server/src/server.ts
+++ b/lsp/server/src/server.ts
@@ -35,7 +35,6 @@ let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
 export let hasDiagnosticRelatedInformationCapability = false;
 
-let extensionTitle = '';
 let updateDiagnosticsSettingCommand = '';
 let diagnosticsSettingSection = '';
 
@@ -51,7 +50,6 @@ connection.onInitialize((params: InitializeParams) => {
 
     // Sets workspace folder to WorkspaceUtils
     WorkspaceUtils.initWorkspaceFolders(workspaceFolders);
-    extensionTitle = params.initializationOptions?.extensionTitle;
     updateDiagnosticsSettingCommand =
         params.initializationOptions?.updateDiagnosticsSettingCommand;
     diagnosticsSettingSection =
@@ -175,11 +173,7 @@ connection.languages.diagnostics.on(async (params) => {
     if (document !== undefined) {
         return {
             kind: DocumentDiagnosticReportKind.Full,
-            items: await validatorManager.validateDocument(
-                settings,
-                document,
-                extensionTitle
-            )
+            items: await validatorManager.validateDocument(settings, document)
         } satisfies DocumentDiagnosticReport;
     } else {
         // We don't know the document. We can either try to read it from disk

--- a/lsp/server/src/test/diagnostic/js/adapters-local-change-not-aware.test.ts
+++ b/lsp/server/src/test/diagnostic/js/adapters-local-change-not-aware.test.ts
@@ -10,29 +10,14 @@ import * as sinon from 'sinon';
 
 import { suite, test, afterEach } from 'mocha';
 
-import { AdaptersLocalChangeNotAware } from '../../../diagnostic/js/adapters-local-change-not-aware';
+import {
+    AdaptersLocalChangeNotAware,
+    URL_FOR_GET_RELATED_LIST_RECORDS_EXTERNAL_DOC,
+    MESSAGE_FOR_GET_RELATED_LIST_RECORDS,
+    MESSAGE_FOR_GET_RELATED_LIST_COUNT
+} from '../../../diagnostic/js/adapters-local-change-not-aware';
 import { parseJs } from '../../../utils/babelUtil';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-
-const relatedRecordsJS = `
-import { LightningElement, wire } from "lwc";
-import { getRelatedListRecords } from "lightning/uiRelatedListApi";
-
-export default class RelatedListRecords extends LightningElement {
-
-  recordId = "0015g00000XYZABC";
-
-  relatedRecords;
-
-  @wire(getRelatedListRecords, {
-    parentRecordId: "$recordId", 
-    relatedListId: "Opportunities",
-    fields: ["Opportunity.Name"],
-  })
-  relatedListHandler({ error, data }) {
-  }
-}
-`;
 
 suite(
     'JS Diagnostics Test Suite - Server - Adapter Local Change Not Aware',
@@ -44,11 +29,21 @@ suite(
         });
 
         test('Wire "getRelatedRecords" produces local-change-not-aware diagnostic', async () => {
+            const jsCode = `
+                import { LightningElement, wire } from "lwc";
+                import { getRelatedListRecords } from "lightning/uiRelatedListApi";
+
+                export default class RelatedListRecords extends LightningElement {
+                    @wire(getRelatedListRecords, {})
+                    relatedListHandler({ error, data }) {
+                    }
+                }
+            `;
             const textDocument = TextDocument.create(
                 'file://test.js',
                 'javascript',
                 1,
-                relatedRecordsJS
+                jsCode
             );
             const jsAstNode = parseJs(textDocument.getText());
             const diagnostics = await rule.validateDocument(
@@ -57,17 +52,52 @@ suite(
             );
 
             assert.equal(diagnostics.length, 1);
-            const { range } = diagnostics[0];
+            const { range, message, code } = diagnostics[0];
 
             const startOffset = textDocument.offsetAt(range.start);
             const endOffset = textDocument.offsetAt(range.end);
 
-            const targetString = relatedRecordsJS.substring(
-                startOffset,
-                endOffset
-            );
+            const targetString = jsCode.substring(startOffset, endOffset);
 
             assert.equal(targetString, 'getRelatedListRecords');
+            assert.equal(message, MESSAGE_FOR_GET_RELATED_LIST_RECORDS);
+            assert.equal(code, URL_FOR_GET_RELATED_LIST_RECORDS_EXTERNAL_DOC);
+        });
+
+        test('Wire "getRelatedListCount" produces local-change-not-aware diagnostic', async () => {
+            const jsCode = `
+                import { LightningElement, wire } from "lwc";
+                import { getRelatedListCount } from "lightning/uiRelatedListApi";
+
+                export default class GetRelatedListCount extends LightningElement {
+                    @wire(getRelatedListCount, {})
+                    relatedListHandler({ error, data }) {
+                    }
+                }
+            `;
+            const textDocument = TextDocument.create(
+                'file://test.js',
+                'javascript',
+                1,
+                jsCode
+            );
+            const jsAstNode = parseJs(textDocument.getText());
+            const diagnostics = await rule.validateDocument(
+                textDocument,
+                jsAstNode
+            );
+
+            assert.equal(diagnostics.length, 1);
+            const { range, message, code } = diagnostics[0];
+
+            const startOffset = textDocument.offsetAt(range.start);
+            const endOffset = textDocument.offsetAt(range.end);
+
+            const targetString = jsCode.substring(startOffset, endOffset);
+
+            assert.equal(targetString, 'getRelatedListCount');
+            assert.equal(message, MESSAGE_FOR_GET_RELATED_LIST_COUNT);
+            assert.equal(code, undefined);
         });
     }
 );

--- a/lsp/server/src/test/validator/graphqlValidator.test.ts
+++ b/lsp/server/src/test/validator/graphqlValidator.test.ts
@@ -7,7 +7,10 @@
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { GraphQLValidator } from '../../validator/gqlValidator';
-import { OversizedRecord } from '../../diagnostic/gql/over-sized-record';
+import {
+    OversizedRecord,
+    RULE_ID
+} from '../../diagnostic/gql/over-sized-record';
 
 import * as assert from 'assert';
 import { suite, test, beforeEach, afterEach } from 'mocha';
@@ -69,6 +72,7 @@ suite('Diagnostics Test Suite - Server - GraphQL Validator', () => {
         );
 
         assert.equal(diagnostics.length, 2);
+        assert.equal(diagnostics[0].data, RULE_ID);
     });
 
     test('Graphql with incorrect syntax produces no diagnostic', async () => {

--- a/lsp/server/src/test/validator/htmlValidator.test.ts
+++ b/lsp/server/src/test/validator/htmlValidator.test.ts
@@ -9,7 +9,10 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { suite, test } from 'mocha';
 import { HTMLValidator } from '../../validator/htmlValidator';
 import * as assert from 'assert';
-import { MobileOfflineFriendly } from '../../diagnostic/html/mobileOfflineFriendly';
+import {
+    MobileOfflineFriendly,
+    RULE_ID
+} from '../../diagnostic/html/mobileOfflineFriendly';
 
 suite('Diagnostics Test Suite - Server - HTML Validator', () => {
     const htmlValidator: HTMLValidator = new HTMLValidator();
@@ -44,6 +47,7 @@ suite('Diagnostics Test Suite - Server - HTML Validator', () => {
             htmlSections[0].data
         );
         assert.equal(diagnostics.length, 2);
+        assert.equal(diagnostics[0].data, RULE_ID);
     });
 
     test('Correct number of nested non-friendly mobile offline base components is determined', async () => {

--- a/lsp/server/src/test/validator/jsValidator.test.ts
+++ b/lsp/server/src/test/validator/jsValidator.test.ts
@@ -12,7 +12,7 @@ import { suite, test } from 'mocha';
 import { JSValidator } from '../../validator/jsValidator';
 import {
     AdaptersLocalChangeNotAware,
-    LOCAL_CHANGE_NOT_AWARE_MESSAGE,
+    MESSAGE_FOR_GET_RELATED_LIST_RECORDS,
     RULE_ID
 } from '../../diagnostic/js/adapters-local-change-not-aware';
 
@@ -54,7 +54,11 @@ suite('Diagnostics Test Suite - Server - JS Validator', () => {
             jsSections[0].data
         );
         assert.equal(diagnostics.length, 1);
-        assert.equal(diagnostics[0].message, LOCAL_CHANGE_NOT_AWARE_MESSAGE);
+        assert.equal(
+            diagnostics[0].message,
+            MESSAGE_FOR_GET_RELATED_LIST_RECORDS
+        );
+        assert.equal(diagnostics[0].data, RULE_ID);
     });
 
     test('No diagnostics return if individually suppressed', async () => {

--- a/lsp/server/src/test/validatorManager.test.ts
+++ b/lsp/server/src/test/validatorManager.test.ts
@@ -10,7 +10,7 @@ import * as assert from 'assert';
 import { suite, test } from 'mocha';
 
 import { ValidatorManager } from '../validatorManager';
-import { LOCAL_CHANGE_NOT_AWARE_MESSAGE } from '../diagnostic/js/adapters-local-change-not-aware';
+import { MESSAGE_FOR_GET_RELATED_LIST_RECORDS } from '../diagnostic/js/adapters-local-change-not-aware';
 
 suite('Diagnostics Test Suite - Server - ValidatorManager', () => {
     const validatorManager = ValidatorManager.createInstance();
@@ -42,10 +42,12 @@ suite('Diagnostics Test Suite - Server - ValidatorManager', () => {
     test('Validate JS file with local change not aware adapter', async () => {
         const diagnostics = await validatorManager.validateDocument(
             {},
-            textDocument,
-            'testExtension'
+            textDocument
         );
         assert.equal(diagnostics.length, 1);
-        assert.equal(diagnostics[0].message, LOCAL_CHANGE_NOT_AWARE_MESSAGE);
+        assert.equal(
+            diagnostics[0].message,
+            MESSAGE_FOR_GET_RELATED_LIST_RECORDS
+        );
     });
 });

--- a/lsp/server/src/validator/baseValidator.ts
+++ b/lsp/server/src/validator/baseValidator.ts
@@ -90,7 +90,15 @@ export abstract class BaseValidator<SupportedType> {
         const diagnosticsArray = await Promise.all(
             activeProducers.map(async (producer) => {
                 try {
-                    return await producer.validateDocument(textDocument, data);
+                    const producerId = producer.getId();
+                    const diagnostics = await producer.validateDocument(
+                        textDocument,
+                        data
+                    );
+                    diagnostics.forEach((diagnostic) => {
+                        diagnostic.data = producerId;
+                    });
+                    return diagnostics;
                 } catch (e) {
                     console.log(
                         `Cannot diagnose document with rule ID ${producer.getId()}: ${(e as Error).message}`

--- a/lsp/server/src/validatorManager.ts
+++ b/lsp/server/src/validatorManager.ts
@@ -38,13 +38,11 @@ export class ValidatorManager {
      * Validate a document by applying all relevant validators based on language.
      * @param setting The diagnostic settings.
      * @param document The document to validate.
-     * @param extensionName The name of the extension (sets diagnostic source).
      * @returns A promise resolving to an array of diagnostics.
      */
     async validateDocument(
         setting: DiagnosticSettings,
-        document: TextDocument,
-        extensionName: string
+        document: TextDocument
     ): Promise<Diagnostic[]> {
         const qualifiers = this.validators.filter(
             (validator) => validator.getLanguageId() === document.languageId
@@ -61,10 +59,7 @@ export class ValidatorManager {
                 return [];
             })
         );
-        const results = diagnosticArray.flat();
-        results.forEach((diagnostic) => (diagnostic.source = extensionName));
-
-        return results;
+        return diagnosticArray.flat();
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8894,7 +8894,7 @@
                 "tslib": "^2.0.3"
             }
         },
-       "node_modules/node-abi": {
+        "node_modules/node-abi": {
             "version": "3.51.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
             "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",


### PR DESCRIPTION
getRelatedListRecords is finalized to 
<img width="948" alt="image" src="https://github.com/user-attachments/assets/04646bf9-5e67-4df6-a7ca-7e47f0cfed98">

getRelatedListCount is finalized to 
<img width="917" alt="image" src="https://github.com/user-attachments/assets/bc7930da-3799-47e0-abd8-cfd9674c303f">
