### PR TITLE
Coverage report posted to codecov

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,40 +1,45 @@
 name: run-tests
 run-name: Installs project and runs project tests
-on: [ push, pull_request ]
+on: [push, pull_request]
 jobs:
-  run-tests-nix:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [ 20, 22 ]
-    name: Tests with code coverage on Ubuntu with Node ${{ matrix.node }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-      - run: |
-          npm install
-          npm run compile
-          # runtTests() which downloads/installs/launches VSCode requires a screen.
-          # Using xvfb-run to attach a virtual screen for CI running on Ubuntu.
-          xvfb-run --server-num=99 --server-args="-screen 0 1024x768x24" npm run test-coverage
-        shell: bash
-      - run: killall Xvfb || true
-  run-tests-win:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        node: [ 20, 22 ]
-    name: Tests with code coverage on Windows with Node ${{ matrix.node }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-      - run: |
-          # On Windows there no need for a screen for runTests() to run successfully.
-          npm install
-          npm run compile
-          npm run test-coverage
-      - run: taskkill /IM Xvfb.exe /F || true
+    run-tests-nix:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node: [20, 22]
+        name: Tests with code coverage on Ubuntu with Node ${{ matrix.node }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node }}
+            - run: |
+                  npm install
+                  npm run compile
+                  # runtTests() which downloads/installs/launches VSCode requires a screen.
+                  # Using xvfb-run to attach a virtual screen for CI running on Ubuntu.
+                  xvfb-run --server-num=99 --server-args="-screen 0 1024x768x24" npm run test-coverage
+              shell: bash
+            - run: killall Xvfb || true
+            - name: Upload coverage to codecov
+              uses: codecov/codecov-action@v3
+              with:
+                  files: coverage/*.json
+                  flags: lsp,extension
+    run-tests-win:
+        runs-on: windows-latest
+        strategy:
+            matrix:
+                node: [20, 22]
+        name: Tests with code coverage on Windows with Node ${{ matrix.node }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node }}
+            - run: |
+                  # On Windows there no need for a screen for runTests() to run successfully.
+                  npm install
+                  npm run compile
+                  npm run test-coverage
+            - run: taskkill /IM Xvfb.exe /F || true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,7 @@ jobs:
             - name: Upload coverage to codecov
               uses: codecov/codecov-action@v3
               with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
                   files: coverage/*.json
                   flags: lsp,extension
     run-tests-win:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/github/salesforce/salesforcedx-vscode-mobile/branch/main/graph/badge.svg?token=PDZHP80RNO)](https://codecov.io/github/salesforce/salesforcedx-vscode-mobile)
+
 # Salesforce Mobile Extensions for Visual Studio Code
 
 This Visual Studio Code extension provides tools to help developers create their Salesforce Mobile experiences in the VSCode development environment.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2024, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: MIT
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+comment:
+    layout: 'header, diff, tree'
+    behavior: default
+    require_changes: false # if true: only post the comment if coverage changes
+    branches: null
+    flags: null
+    paths: null
+flags:
+    extension:
+        paths:
+            - src/
+    lsp:
+        paths:
+            - lsp/

--- a/test/suite/index.ts
+++ b/test/suite/index.ts
@@ -28,7 +28,7 @@ export async function run(): Promise<void> {
         nyc = new NYC({
             ...baseConfig,
             cwd: path.join(__dirname, '..', '..', '..'),
-            reporter: ['text-summary', 'html', 'text', 'lcov'],
+            reporter: ['text-summary', 'html', 'text', 'lcov', 'json'],
             all: true,
             silent: false,
             instrument: true,


### PR DESCRIPTION
### What does this PR do?
Post nyc code coverage report to `https://app.codecov.io/`, which can be referenced by perf dashboard.
### What issues does this PR fix or reference?
