### PR TITLE
mkdirSync can throw error

### DIFF
--- a/scripts/copyResources.js
+++ b/scripts/copyResources.js
@@ -6,5 +6,5 @@ const outDir = path.join(projectRoot, 'out', 'src', 'resources');
 const sourceFile = path.join(projectRoot, 'resources', 'component-experiences.yaml');
 const destFile = path.join(outDir, 'component-experiences.yaml');
 
-fs.mkdirSync(outDir);
+fs.mkdirSync(outDir, { recursive: true });
 fs.copyFileSync(sourceFile, destFile);


### PR DESCRIPTION
### What does this PR do?
Successively running commands `npm run compile` and then `npm run test` threw an error below. To handle this gracefully `mkdirSync` is called with an option so that an error won't be thrown if the directory exists.

```
Error: EEXIST: file already exists, mkdir '/Users/t.arai/Documents/codebase/salesforcedx-vscode-mobile/out/src/resources'
    at Object.mkdirSync (node:fs:1371:26)
    at Object.<anonymous> (/Users/t.arai/Documents/codebase/salesforcedx-vscode-mobile/scripts/copyResources.js:9:4)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49 {
  errno: -17,
  code: 'EEXIST',
  syscall: 'mkdir',
  path: '/Users/t.arai/Documents/codebase/salesforcedx-vscode-mobile/out/src/resources'
}
```
