### PR TITLE
Md file link for diagnostic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "salesforcedx-vscode-mobile",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "salesforcedx-vscode-mobile",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "@babel/traverse": "^7.25.9",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/salesforce/salesforcedx-vscode-mobile.git"
+        "url": "https://github.com/salesforce/salesforcedx-vscode-mobile"
     },
     "license": "SEE LICENSE IN LICENSE.txt",
     "icon": "images/package-icon.png",

--- a/src/commands/lint/configureLintingToolsCommand.ts
+++ b/src/commands/lint/configureLintingToolsCommand.ts
@@ -250,7 +250,11 @@ export class ConfigureLintingToolsCommand {
 }
 
 export function registerCommand(context: ExtensionContext) {
-    commands.registerCommand(configureLintingToolsCommand, async () => {
-        await ConfigureLintingToolsCommand.configure();
-    });
+    const disposable = commands.registerCommand(
+        configureLintingToolsCommand,
+        async () => {
+            await ConfigureLintingToolsCommand.configure();
+        }
+    );
+    context.subscriptions.push(disposable);
 }

--- a/src/commands/settings/settings.ts
+++ b/src/commands/settings/settings.ts
@@ -20,8 +20,9 @@ export const SECTION_DIAGNOSTICS = `mobileDiagnostics`;
 
 export function registerCommand(context: vscode.ExtensionContext) {
     const command = getUpdateDiagnosticsSettingCommand(context);
-    context.subscriptions.push(
-        vscode.commands.registerCommand(command, async (diagnosticSetting) => {
+    const disposable = vscode.commands.registerCommand(
+        command,
+        async (diagnosticSetting) => {
             const config =
                 vscode.workspace.getConfiguration(SECTION_DIAGNOSTICS);
             const { suppressAll, suppressByRuleId } = diagnosticSetting;
@@ -45,6 +46,7 @@ export function registerCommand(context: vscode.ExtensionContext) {
                     vscode.ConfigurationTarget.Workspace
                 );
             }
-        })
+        }
     );
+    context.subscriptions.push(disposable);
 }

--- a/src/commands/wizard/onboardingWizard.ts
+++ b/src/commands/wizard/onboardingWizard.ts
@@ -56,7 +56,7 @@ export function onActivate(context: vscode.ExtensionContext) {
 }
 
 export function registerCommand(context: vscode.ExtensionContext) {
-    vscode.commands.registerCommand(
+    const disposable = vscode.commands.registerCommand(
         wizardCommand,
         async (fromPostProjectConfiguration: boolean = false) => {
             if (fromPostProjectConfiguration) {
@@ -93,4 +93,5 @@ export function registerCommand(context: vscode.ExtensionContext) {
             }
         }
     );
+    context.subscriptions.push(disposable);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     const command = getUpdateDiagnosticsSettingCommand(context);
 
-    lspClient.activate(context, command, SECTION_DIAGNOSTICS);
+    // Enable LSP only if opened workspace is a sfdx project.
+    if (WorkspaceUtils.isSfdxProjectOpened()) {
+        lspClient.activate(context, command, SECTION_DIAGNOSTICS);
+    }
 }
 
 // This method is called when your extension is deactivated

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -22,6 +22,10 @@ export function activate(
     updateDiagnosticsSettingCommand: string,
     diagnosticsSettingSection: string
 ) {
+    // Get extension name
+    const extensionTitle =
+        context.extension.packageJSON.contributes.configuration.title;
+
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
         path.join('out', 'src', 'lsp', 'server', 'server.js')
@@ -54,7 +58,8 @@ export function activate(
         },
         initializationOptions: {
             updateDiagnosticsSettingCommand,
-            diagnosticsSettingSection
+            diagnosticsSettingSection,
+            extensionTitle
         }
     };
 

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -7,6 +7,7 @@
 
 import * as path from 'path';
 import { workspace, ExtensionContext } from 'vscode';
+import { version, repository } from '../../../package.json';
 
 import {
     LanguageClient,
@@ -25,6 +26,8 @@ export function activate(
     // Get extension name
     const extensionTitle =
         context.extension.packageJSON.contributes.configuration.title;
+
+    const diagnosticBaseRootUrl = `${repository.url}/blob/v${version}/src/docs`;
 
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
@@ -59,7 +62,8 @@ export function activate(
         initializationOptions: {
             updateDiagnosticsSettingCommand,
             diagnosticsSettingSection,
-            extensionTitle
+            extensionTitle,
+            diagnosticBaseRootUrl
         }
     };
 

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -27,7 +27,7 @@ export function activate(
     const extensionTitle =
         context.extension.packageJSON.contributes.configuration.title;
 
-    const diagnosticBaseRootUrl = `${repository.url}/blob/v${version}/src/docs`;
+    const diagnosticBaseRootUrl = `${repository.url}/blob/v${version}/src/lsp/docs`;
 
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(

--- a/src/lsp/server/diagnostics/DiagnosticProducer.ts
+++ b/src/lsp/server/diagnostics/DiagnosticProducer.ts
@@ -9,7 +9,7 @@ import { Diagnostic } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 export abstract class DiagnosticProducer<T> {
-    baseDocUrl: string;
+    private baseDocUrl: string;
 
     constructor(baseDocUrl: string) {
         this.baseDocUrl = baseDocUrl;

--- a/src/lsp/server/diagnostics/DiagnosticProducer.ts
+++ b/src/lsp/server/diagnostics/DiagnosticProducer.ts
@@ -15,6 +15,11 @@ export interface DiagnosticProducer<T> {
     getId(): string;
 
     /**
+     * Get the external doc url about the diagnostic produced by this producer.
+     */
+    getDocUrl(): string | undefined;
+
+    /**
      * Validate the parsed text document as astNode and return a list of diagnostics.
      * @param textDocument the language server text document.
      * @param data usually parsed document body.

--- a/src/lsp/server/diagnostics/DiagnosticProducer.ts
+++ b/src/lsp/server/diagnostics/DiagnosticProducer.ts
@@ -8,16 +8,33 @@
 import { Diagnostic } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-export interface DiagnosticProducer<T> {
+export abstract class DiagnosticProducer<T> {
+    baseDocUrl: string;
+
+    constructor(baseDocUrl: string) {
+        this.baseDocUrl = baseDocUrl;
+    }
+
     /**
      * Get the Id for the diagnostic producer.
      */
-    getId(): string;
+    abstract getId(): string;
 
     /**
-     * Get the external doc url about the diagnostic produced by this producer.
+     * Flag to validator if this producer has documentation md file, default to have doc.
      */
-    getDocUrl(): string | undefined;
+    hasDocumentation(): boolean {
+        return true;
+    }
+
+    /**
+     * Get the doc url about the diagnostic produced by this producer.
+     */
+    getDocUrl(): string | undefined {
+        return this.hasDocumentation()
+            ? `${this.baseDocUrl}/${this.getId()}.md`
+            : undefined;
+    }
 
     /**
      * Validate the parsed text document as astNode and return a list of diagnostics.
@@ -25,7 +42,7 @@ export interface DiagnosticProducer<T> {
      * @param data usually parsed document body.
      * @returns An array of diagnostics found within ast node.
      */
-    validateDocument(
+    abstract validateDocument(
         textDocument: TextDocument,
         data: T
     ): Promise<Diagnostic[]>;

--- a/src/lsp/server/diagnostics/gql/over-sized-record.ts
+++ b/src/lsp/server/diagnostics/gql/over-sized-record.ts
@@ -59,6 +59,10 @@ export class OversizedRecord implements DiagnosticProducer<ASTNode> {
     getId(): string {
         return RULE_ID;
     }
+
+    getDocUrl(): string | undefined {
+        return undefined;
+    }
 }
 
 export interface OverSizedDiagnostics {

--- a/src/lsp/server/diagnostics/gql/over-sized-record.ts
+++ b/src/lsp/server/diagnostics/gql/over-sized-record.ts
@@ -28,7 +28,11 @@ export const OVER_SIZED_RECORD_MESSAGE =
 const SEVERITY = DiagnosticSeverity.Information;
 
 export const RULE_ID = 'over-sized-record';
-export class OversizedRecord implements DiagnosticProducer<ASTNode> {
+export class OversizedRecord extends DiagnosticProducer<ASTNode> {
+    constructor(baseDocUrl: string) {
+        super(baseDocUrl);
+    }
+
     async validateDocument(
         textDocument: TextDocument,
         rootNode: ASTNode
@@ -58,10 +62,6 @@ export class OversizedRecord implements DiagnosticProducer<ASTNode> {
 
     getId(): string {
         return RULE_ID;
-    }
-
-    getDocUrl(): string | undefined {
-        return undefined;
     }
 }
 

--- a/src/lsp/server/diagnostics/html/mobileOfflineFriendly.ts
+++ b/src/lsp/server/diagnostics/html/mobileOfflineFriendly.ts
@@ -17,13 +17,17 @@ const baseComponentsAttributes = { values: getBaseComponentsAttributes() };
 
 export const RULE_ID = 'mobile-offline-friendly';
 
-export class MobileOfflineFriendly implements DiagnosticProducer<HTMLDocument> {
+export class MobileOfflineFriendly extends DiagnosticProducer<HTMLDocument> {
+    constructor(baseDocUrl: string) {
+        super(baseDocUrl);
+    }
+
     getId(): string {
         return RULE_ID;
     }
 
-    getDocUrl(): string | undefined {
-        return undefined;
+    hasDocumentation(): boolean {
+        return false;
     }
 
     async validateDocument(

--- a/src/lsp/server/diagnostics/html/mobileOfflineFriendly.ts
+++ b/src/lsp/server/diagnostics/html/mobileOfflineFriendly.ts
@@ -22,6 +22,10 @@ export class MobileOfflineFriendly implements DiagnosticProducer<HTMLDocument> {
         return RULE_ID;
     }
 
+    getDocUrl(): string | undefined {
+        return undefined;
+    }
+
     async validateDocument(
         textDocument: TextDocument,
         data: HTMLDocument

--- a/src/lsp/server/diagnostics/js/adapters-local-change-not-aware.ts
+++ b/src/lsp/server/diagnostics/js/adapters-local-change-not-aware.ts
@@ -47,6 +47,10 @@ export class AdaptersLocalChangeNotAware implements DiagnosticProducer<Node> {
         return RULE_ID;
     }
 
+    getDocUrl(): string | undefined {
+        return undefined;
+    }
+
     validateDocument(
         textDocument: TextDocument,
         node: Node

--- a/src/lsp/server/diagnostics/js/adapters-local-change-not-aware.ts
+++ b/src/lsp/server/diagnostics/js/adapters-local-change-not-aware.ts
@@ -42,13 +42,13 @@ export const RULE_ID = 'adapters-local-change-not-aware';
 /**
  * Produce diagnostics for adapter which works offline but doesn't handle local change.
  */
-export class AdaptersLocalChangeNotAware implements DiagnosticProducer<Node> {
-    getId(): string {
-        return RULE_ID;
+export class AdaptersLocalChangeNotAware extends DiagnosticProducer<Node> {
+    constructor(baseDocUrl: string) {
+        super(baseDocUrl);
     }
 
-    getDocUrl(): string | undefined {
-        return undefined;
+    getId(): string {
+        return RULE_ID;
     }
 
     validateDocument(

--- a/src/lsp/server/server.ts
+++ b/src/lsp/server/server.ts
@@ -38,6 +38,7 @@ export let hasDiagnosticRelatedInformationCapability = false;
 let updateDiagnosticsSettingCommand = '';
 let diagnosticsSettingSection = '';
 let extensionTitle = '';
+let diagnosticBaseRootUrl = '';
 
 // initialize default settings
 let settings = getSettings({});
@@ -52,6 +53,7 @@ connection.onInitialize((params: InitializeParams) => {
     // Sets workspace folder to WorkspaceUtils
     ServerWorkspace.initWorkspaceFolders(workspaceFolders);
     extensionTitle = params.initializationOptions?.extensionTitle;
+    diagnosticBaseRootUrl = params.initializationOptions?.diagnosticBaseRootUrl;
 
     updateDiagnosticsSettingCommand =
         params.initializationOptions?.updateDiagnosticsSettingCommand;
@@ -173,7 +175,10 @@ documents.onDidClose((e) => {
 
 connection.languages.diagnostics.on(async (params) => {
     if (validatorManager === undefined) {
-        validatorManager = ValidatorManager.createInstance(extensionTitle);
+        validatorManager = ValidatorManager.createInstance(
+            extensionTitle,
+            diagnosticBaseRootUrl
+        );
     }
     const document = documents.get(params.textDocument.uri);
     if (document !== undefined) {

--- a/src/lsp/server/server.ts
+++ b/src/lsp/server/server.ts
@@ -37,11 +37,12 @@ export let hasDiagnosticRelatedInformationCapability = false;
 
 let updateDiagnosticsSettingCommand = '';
 let diagnosticsSettingSection = '';
+let extensionTitle = '';
 
 // initialize default settings
 let settings = getSettings({});
 
-const validatorManager = ValidatorManager.createInstance();
+let validatorManager: ValidatorManager;
 
 const documentCache: Map<string, TextDocument> = new Map();
 
@@ -50,6 +51,7 @@ connection.onInitialize((params: InitializeParams) => {
 
     // Sets workspace folder to WorkspaceUtils
     ServerWorkspace.initWorkspaceFolders(workspaceFolders);
+    extensionTitle = params.initializationOptions?.extensionTitle;
 
     updateDiagnosticsSettingCommand =
         params.initializationOptions?.updateDiagnosticsSettingCommand;
@@ -170,6 +172,9 @@ documents.onDidClose((e) => {
 });
 
 connection.languages.diagnostics.on(async (params) => {
+    if (validatorManager === undefined) {
+        validatorManager = ValidatorManager.createInstance(extensionTitle);
+    }
     const document = documents.get(params.textDocument.uri);
     if (document !== undefined) {
         return {

--- a/src/lsp/server/validatorManager.ts
+++ b/src/lsp/server/validatorManager.ts
@@ -22,7 +22,14 @@ export class ValidatorManager {
     // Store all available validators
     private validators: BaseValidator<SupportedType>[] = [];
 
-    private constructor() {}
+    private source: string;
+
+    /**
+     * @param source the diagnostic source.
+     */
+    private constructor(source: string) {
+        this.source = source;
+    }
 
     /**
      * Adds a validator to the manager’s collection.
@@ -99,8 +106,11 @@ export class ValidatorManager {
                 return [];
             })
         );
-
-        return sectionDiagnostics.flat();
+        const result = sectionDiagnostics.flat();
+        result.forEach((diagnostic) => {
+            diagnostic.source = this.source;
+        });
+        return result;
     }
 
     /**
@@ -135,8 +145,8 @@ export class ValidatorManager {
      * with relevant diagnostic producers.
      * @returns ValidatorManager instance
      */
-    public static createInstance(): ValidatorManager {
-        const validatorManager = new ValidatorManager();
+    public static createInstance(source: string): ValidatorManager {
+        const validatorManager = new ValidatorManager(source);
         // Populate GraphQLValidator
         const gqlValidator = new GraphQLValidator();
         gqlValidator.addProducer(new OversizedRecord());

--- a/src/lsp/server/validatorManager.ts
+++ b/src/lsp/server/validatorManager.ts
@@ -22,10 +22,11 @@ export class ValidatorManager {
     // Store all available validators
     private validators: BaseValidator<SupportedType>[] = [];
 
+    // The source value for diagnostic.
     private source: string;
 
     /**
-     * @param source the diagnostic source.
+     * @param source The diagnostic source.
      */
     private constructor(source: string) {
         this.source = source;
@@ -145,19 +146,22 @@ export class ValidatorManager {
      * with relevant diagnostic producers.
      * @returns ValidatorManager instance
      */
-    public static createInstance(source: string): ValidatorManager {
+    public static createInstance(
+        source: string,
+        baseDocUrl: string
+    ): ValidatorManager {
         const validatorManager = new ValidatorManager(source);
         // Populate GraphQLValidator
         const gqlValidator = new GraphQLValidator();
-        gqlValidator.addProducer(new OversizedRecord());
+        gqlValidator.addProducer(new OversizedRecord(baseDocUrl));
         validatorManager.addValidator(gqlValidator);
 
         const jsValidator = new JSValidator();
-        jsValidator.addProducer(new AdaptersLocalChangeNotAware());
+        jsValidator.addProducer(new AdaptersLocalChangeNotAware(baseDocUrl));
         validatorManager.addValidator(jsValidator);
 
         const htmlValidator = new HTMLValidator();
-        htmlValidator.addProducer(new MobileOfflineFriendly());
+        htmlValidator.addProducer(new MobileOfflineFriendly(baseDocUrl));
         validatorManager.addValidator(htmlValidator);
 
         return validatorManager;

--- a/src/lsp/server/validators/baseValidator.ts
+++ b/src/lsp/server/validators/baseValidator.ts
@@ -91,12 +91,20 @@ export abstract class BaseValidator<SupportedType> {
             activeProducers.map(async (producer) => {
                 try {
                     const producerId = producer.getId();
+                    const docUrl = producer.getDocUrl();
                     const diagnostics = await producer.validateDocument(
                         textDocument,
                         data
                     );
                     diagnostics.forEach((diagnostic) => {
                         diagnostic.data = producerId;
+                        // Show id as link label and docUrl as link href
+                        diagnostic.code = producerId;
+                        if (docUrl !== undefined) {
+                            diagnostic.codeDescription = {
+                                href: docUrl
+                            };
+                        }
                     });
                     return diagnostics;
                 } catch (e) {

--- a/test/suite/lsp/server/diagnostics/DiagnosticProducer.test.ts
+++ b/test/suite/lsp/server/diagnostics/DiagnosticProducer.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { suite, test } from 'mocha';
+import { DiagnosticProducer } from '../../../../../src/lsp/server/diagnostics/DiagnosticProducer';
+import { Diagnostic } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import * as assert from 'assert';
+
+suite('DiagnosticProducer Test Suite - Server', ()=>{
+
+    test('getBaseDocUrl returns correct value', () => {
+        const sampleProducer = new SampleProducer('https://abc.com');
+        const fullUrl = sampleProducer.getDocUrl();
+        assert.equal(fullUrl, 'https://abc.com/sample-rule-id.md')
+    });
+
+    test('getBaseDocUrl returns correct value', () => {
+        const sampleProducer = new SampleProducer('https://abc.com', false);
+        const fullUrl = sampleProducer.getDocUrl();
+        assert.equal(fullUrl, undefined);
+    });
+
+});
+
+class SampleProducer extends DiagnosticProducer<string> {
+    hasDoc: boolean;
+    constructor(baseDocUrl: string, hasDoc: boolean = true) {
+        super(baseDocUrl);
+        this.hasDoc = hasDoc;
+    }
+
+    getId(): string {
+       return 'sample-rule-id';
+    }
+
+    hasDocumentation(): boolean {
+        return this.hasDoc;
+    }
+
+    validateDocument(textDocument: TextDocument, data: string): Promise<Diagnostic[]> {
+       return Promise.resolve([]);
+    }
+}
+
+
+

--- a/test/suite/lsp/server/diagnostics/gql/over-sized-record.test.ts
+++ b/test/suite/lsp/server/diagnostics/gql/over-sized-record.test.ts
@@ -19,11 +19,12 @@ import {
 import { OrgUtils } from '../../../../../../src/lsp/server/utils/orgUtils';
 
 import { ObjectInfoRepresentation } from '../../../../../../src/lsp/server/types';
+import { repository } from '../../../../../../package.json';
 
 suite(
     'GraphQL Diagnostics Test Suite - Server - Oversized GraphQL Field',
     () => {
-        let oversizedRecordProducer = new OversizedRecord();
+        let oversizedRecordProducer = new OversizedRecord(repository.url);
 
         let sandbox: sinon.SinonSandbox;
         beforeEach(function () {

--- a/test/suite/lsp/server/diagnostics/js/adapters-local-change-not-aware.test.ts
+++ b/test/suite/lsp/server/diagnostics/js/adapters-local-change-not-aware.test.ts
@@ -18,11 +18,12 @@ import {
 } from '../../../../../../src/lsp/server/diagnostics/js/adapters-local-change-not-aware';
 import { parseJs } from '../../../../../../src/lsp/server/utils/babelUtil';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { repository } from '../../../../../../package.json';
 
 suite(
     'JS Diagnostics Test Suite - Server - Adapter Local Change Not Aware',
     () => {
-        const rule = new AdaptersLocalChangeNotAware();
+        const rule = new AdaptersLocalChangeNotAware(repository.url);
 
         afterEach(function () {
             sinon.restore();

--- a/test/suite/lsp/server/validatorManager.test.ts
+++ b/test/suite/lsp/server/validatorManager.test.ts
@@ -9,10 +9,11 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as assert from 'assert';
 import { suite, test } from 'mocha';
 import { ValidatorManager } from  '../../../../src/lsp/server/validatorManager';
-import { MESSAGE_FOR_GET_RELATED_LIST_RECORDS } from '../../../../src/lsp/server/diagnostics/js/adapters-local-change-not-aware';
+import { MESSAGE_FOR_GET_RELATED_LIST_RECORDS, RULE_ID as LOCAL_CHANGE_NOT_AWARE_ADAPTERS } from '../../../../src/lsp/server/diagnostics/js/adapters-local-change-not-aware';
 
 suite('Diagnostics Test Suite - Server - ValidatorManager', () => {
-    const validatorManager = ValidatorManager.createInstance();
+    const source = 'sample extension title';
+    const validatorManager = ValidatorManager.createInstance(source);
     const textDocument = TextDocument.create(
         'file://test.js',
         'javascript',
@@ -44,9 +45,12 @@ suite('Diagnostics Test Suite - Server - ValidatorManager', () => {
             textDocument
         );
         assert.equal(diagnostics.length, 1);
+        const diagnostic = diagnostics[0];
         assert.equal(
-            diagnostics[0].message,
+            diagnostic.message,
             MESSAGE_FOR_GET_RELATED_LIST_RECORDS
         );
+        assert.equal(diagnostic.source, source);
+        assert.equal(diagnostic.code, LOCAL_CHANGE_NOT_AWARE_ADAPTERS);
     });
 });

--- a/test/suite/lsp/server/validatorManager.test.ts
+++ b/test/suite/lsp/server/validatorManager.test.ts
@@ -10,10 +10,12 @@ import * as assert from 'assert';
 import { suite, test } from 'mocha';
 import { ValidatorManager } from  '../../../../src/lsp/server/validatorManager';
 import { MESSAGE_FOR_GET_RELATED_LIST_RECORDS, RULE_ID as LOCAL_CHANGE_NOT_AWARE_ADAPTERS } from '../../../../src/lsp/server/diagnostics/js/adapters-local-change-not-aware';
+import { repository } from '../../../../package.json';
 
 suite('Diagnostics Test Suite - Server - ValidatorManager', () => {
     const source = 'sample extension title';
-    const validatorManager = ValidatorManager.createInstance(source);
+    const baseDocUrl = `${repository.url}/blob/main/src/docs`;
+    const validatorManager = ValidatorManager.createInstance(source, baseDocUrl);
     const textDocument = TextDocument.create(
         'file://test.js',
         'javascript',
@@ -52,5 +54,9 @@ suite('Diagnostics Test Suite - Server - ValidatorManager', () => {
         );
         assert.equal(diagnostic.source, source);
         assert.equal(diagnostic.code, LOCAL_CHANGE_NOT_AWARE_ADAPTERS);
+        assert.equal(
+            diagnostic.codeDescription?.href, 
+            'https://github.com/salesforce/salesforcedx-vscode-mobile/blob/main/src/docs/adapters-local-change-not-aware.md'
+        );
     });
 });

--- a/test/suite/lsp/server/validators/graphqlValidator.test.ts
+++ b/test/suite/lsp/server/validators/graphqlValidator.test.ts
@@ -18,6 +18,7 @@ import * as sinon from 'sinon';
 import { OrgUtils } from '../../../../../src/lsp/server/utils/orgUtils';
 import * as Book__c from '../testFixture/objectInfos/Book__c.json';
 import { ObjectInfoRepresentation } from  '../../../../../src/lsp/server/types';
+import { repository } from '../../../../../package.json';
 
 suite('Diagnostics Test Suite - Server - GraphQL Validator', () => {
     let sandbox: sinon.SinonSandbox;
@@ -61,7 +62,7 @@ suite('Diagnostics Test Suite - Server - GraphQL Validator', () => {
         );
 
         const graphqlValidator = new GraphQLValidator();
-        graphqlValidator.addProducer(new OversizedRecord());
+        graphqlValidator.addProducer(new OversizedRecord(repository.url));
         const sections =
             graphqlValidator.gatherDiagnosticSections(textDocument);
         assert.equal(sections.length, 1);
@@ -91,7 +92,7 @@ suite('Diagnostics Test Suite - Server - GraphQL Validator', () => {
             `
         );
         const graphqlValidator = new GraphQLValidator();
-        graphqlValidator.addProducer(new OversizedRecord());
+        graphqlValidator.addProducer(new OversizedRecord(repository.url));
         const sections =
             graphqlValidator.gatherDiagnosticSections(textDocument);
         assert.equal(sections.length, 0);

--- a/test/suite/lsp/server/validators/htmlValidator.test.ts
+++ b/test/suite/lsp/server/validators/htmlValidator.test.ts
@@ -13,10 +13,11 @@ import {
     MobileOfflineFriendly,
     RULE_ID
 } from '../../../../../src/lsp/server/diagnostics/html/mobileOfflineFriendly';
+import { repository } from '../../../../../package.json';
 
 suite('Diagnostics Test Suite - Server - HTML Validator', () => {
     const htmlValidator: HTMLValidator = new HTMLValidator();
-    htmlValidator.addProducer(new MobileOfflineFriendly());
+    htmlValidator.addProducer(new MobileOfflineFriendly(repository.url));
 
     test('Correct number of non-friendly mobile offline base components is determined', async () => {
         const textDocument = TextDocument.create(

--- a/test/suite/lsp/server/validators/jsValidator.test.ts
+++ b/test/suite/lsp/server/validators/jsValidator.test.ts
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
@@ -15,10 +16,11 @@ import {
     MESSAGE_FOR_GET_RELATED_LIST_RECORDS,
     RULE_ID
 } from '../../../../../src/lsp/server/diagnostics/js/adapters-local-change-not-aware';
+import { repository } from '../../../../../package.json';
 
 suite('Diagnostics Test Suite - Server - JS Validator', () => {
     const jsValidator = new JSValidator();
-    jsValidator.addProducer(new AdaptersLocalChangeNotAware());
+    jsValidator.addProducer(new AdaptersLocalChangeNotAware(repository.url));
 
     const textDocument = TextDocument.create(
         'file://test.js',


### PR DESCRIPTION
Clive finished the md file writeup in [this merged pr](https://github.com/salesforce/salesforcedx-vscode-mobile/pull/165).  here we updated the code to point to the md file when diagnostic is rendered over mouse over.   

It looks like below and now it matches what eslint plugin reported problems for vscode now :)  
<img width="820" alt="image" src="https://github.com/user-attachments/assets/d1040a09-d47a-4d03-a709-e036d689ecb8" />

