### PR TITLE
chore: bump version to 0.6.0 for PFT release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "salesforcedx-vscode-mobile",
     "displayName": "%extension.displayName%",
     "description": "%extension.description%",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "publisher": "salesforce",
     "engines": {
         "vscode": "^1.77.0",


### PR DESCRIPTION
## Summary
- Bumps extension version from 0.5.0 to 0.6.0 in preparation for the Product Feature Tracking (PFT) release.

## Test plan
- [ ] Verify `package.json` version is `0.6.0`
- [ ] Confirm extension builds and packages successfully with the new version